### PR TITLE
Setproperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ git:
 #before_script: # homebrew for mac
 #  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Setfield"); Pkg.test("Setfield"; coverage=true)'
+# uncomment the following lines to override the default test script
+script:
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("Setfield"); VERSION < v"0.7-" && Pkg.add("StaticArrays"); Pkg.test("Setfield"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -9,14 +9,14 @@ if Pkg.installed("StaticArrays") != nothing
 end
 
 if isdefined(Base, :getproperty)
-    nothing
+    using Base: getproperty
 else
     const getproperty = getfield
     # the following breaks type stability:
     # @inline getproperty(obj, name) = getfield(obj, name)
 end
 if isdefined(Base, :setproperty!)
-    nothing
+    using Base: setproperty!
 else
     const setproperty! = setfield!
     # @inline setproperty!(obj, name, val) = setfield!(obj, name, val)

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -8,6 +8,20 @@ if Pkg.installed("StaticArrays") != nothing
     hassetindex!(::StaticArrays.StaticArray) = false
 end
 
+if isdefined(Base, :getproperty)
+    nothing
+else
+    const getproperty = getfield
+    # the following breaks type stability:
+    # @inline getproperty(obj, name) = getfield(obj, name)
+end
+if isdefined(Base, :setproperty!)
+    nothing
+else
+    const setproperty! = setfield!
+    # @inline setproperty!(obj, name, val) = setfield!(obj, name, val)
+end
+
 include("lens.jl")
 include("sugar.jl")
 end

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -58,7 +58,7 @@ end
 function parse_fieldlens(ex)
     @assert length(ex.args) == 2
     field = ex.args[2]
-    :(FieldLens{$field}())
+    :(PropertyLens{$field}())
 end
 
 function parse_obj_lens(ex)
@@ -149,7 +149,7 @@ macro focus(ex)
     end
 end
 
-print_application(io::IO, l::FieldLens{field}) where {field} = print(io, ".", field)
+print_application(io::IO, l::PropertyLens{field}) where {field} = print(io, ".", field)
 print_application(io::IO, l::IndexLens) = print(io, "[", join(l.indices, ", "), "]")
 print_application(io::IO, l::IdentityLens) = print(io, "")
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-StaticArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,20 @@ end
     @test m.a === m_inner_init
 end
 
+# https://github.com/tkf/Reconstructables.jl#how-to-use-type-parameters
+struct B{T, X, Y}
+    x::X
+    y::Y
+    B{T}(x::X, y::Y = 2) where {T, X, Y} = new{T, X, Y}(x, y)
+end
+Setfield.constructor_of(::Type{<: B{T}}) where T = B{T}
+
+@testset "type change during @set" begin
+    obj = B{1}(2,3)
+    obj2 = @set obj.y = :three
+    @test obj2 === B{1}(2, :three)
+end
+
 @static if Pkg.installed("StaticArrays") != nothing
     using StaticArrays
     obj = StaticArrays.@SMatrix [1 2; 3 4]

--- a/test/spaceship.jl
+++ b/test/spaceship.jl
@@ -1,0 +1,23 @@
+using StaticArrays
+struct Person
+    name::Symbol
+    birthyear::Int
+end
+
+struct SpaceShip
+    captain::Person
+    velocity::SVector{3, Float64}
+    position::SVector{3, Float64}
+end
+
+@testset "SpaceShip" begin
+    s = SpaceShip(
+                  Person("julia", 2009),
+                  [0,0,0],
+                  [0,0,0]
+                 )
+    s = @set s.captain.name = "JULIA"
+    s = @set s.velocity[1] += 10
+    s = @set s.position[2]  = 20
+    @test s === SpaceShip(Person("JULIA", 2009), [10.0, 0.0, 0.0], [0.0, 20.0, 0.0])
+end


### PR DESCRIPTION
@tkf

```julia
+# https://github.com/tkf/Reconstructables.jl#how-to-use-type-parameters
+struct B{T, X, Y}
+    x::X
+    y::Y
+    B{T}(x::X, y::Y = 2) where {T, X, Y} = new{T, X, Y}(x, y)
+end
+Setfield.constructor_of(::Type{<: B{T}}) where T = B{T}
+
+@testset "type change during @set" begin
+    obj = B{1}(2,3)
+    obj2 = @set obj.y = :three
+    @test obj2 === B{1}(2, :three)
+end
```
works now!