### PR TITLE
Interoperability

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+MacroTools

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -24,4 +24,6 @@ end
 
 include("lens.jl")
 include("sugar.jl")
+include("macrotools.jl")
+include("settable.jl")
 end

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -117,7 +117,9 @@ end
 #     ret
 # end
 
-constructor_of(::Type{T}) where {T} = T
+@generated constructor_of(::Type{T}) where T =
+    getfield(T.name.module, Symbol(T.name.name))
+constructor_of(T::UnionAll) = constructor_of(T.body)
 
 @generated function setproperty(obj, ::Val{name}, val) where {name}
     T = obj

--- a/src/macrotools.jl
+++ b/src/macrotools.jl
@@ -1,4 +1,7 @@
 using MacroTools
+
+const STRUCTSYMBOL = VERSION < v"0.7-" ? :type : :struct
+
 function parse_error(ex)
     throw(ArgumentError("Cannot parse typedefinition from $ex."))
 end
@@ -45,6 +48,7 @@ function splittypedef(ex)
     d
 end
 
+
 function combinetypedef(d)
     name = d[:name]
     parameters = d[:params]
@@ -58,7 +62,8 @@ function combinetypedef(d)
         $(fields...)
         $(d[:constructors]...)
     end
-    Expr(:type, d[:mutable], header, body)
+
+    Expr(STRUCTSYMBOL, d[:mutable], header, body)
 end
 
 function combinefield(x)

--- a/src/macrotools.jl
+++ b/src/macrotools.jl
@@ -2,8 +2,13 @@ using MacroTools
 
 const STRUCTSYMBOL = VERSION < v"0.7-" ? :type : :struct
 
+struct ParseError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, ex::ParseError) = print(io, "ParseError: $(ex.msg)")
+
 function parse_error(ex)
-    throw(ArgumentError("Cannot parse typedefinition from $ex."))
+    throw(ParseError("Cannot parse typedefinition from $ex."))
 end
 
 function splittypedef(ex)
@@ -47,6 +52,18 @@ function splittypedef(ex)
         end
     end
     d
+end
+
+
+function is_trivial_struct(ex)
+    try
+        return isempty(splittypedef(ex)[:constructors])
+    catch err
+        if err isa ParseError
+            return false
+        end
+        throw()
+    end
 end
 
 

--- a/src/macrotools.jl
+++ b/src/macrotools.jl
@@ -6,18 +6,9 @@ function parse_error(ex)
     throw(ArgumentError("Cannot parse typedefinition from $ex."))
 end
 
-function statements(ex)
-    exprs = []
-    if isexpr(ex, :block)
-        append!(exprs, vcat(map(statements, ex.args)...))
-    else
-        push!(exprs, ex)
-    end
-    return exprs
-end
-
 function splittypedef(ex)
     ex = MacroTools.striplines(ex)
+    ex = MacroTools.flatten(ex)
     d = Dict{Symbol, Any}()
     if @capture(ex, struct header_ body__ end)
         d[:mutable] = false
@@ -52,7 +43,7 @@ function splittypedef(ex)
         elseif item isa Symbol
             push!(d[:fields], (item, Any))
         else
-            append!(d[:constructors], statements(item))
+            push!(d[:constructors], item)
         end
     end
     d

--- a/src/macrotools.jl
+++ b/src/macrotools.jl
@@ -1,0 +1,67 @@
+using MacroTools
+function parse_error(ex)
+    throw(ArgumentError("Cannot parse typedefinition from $ex."))
+end
+    
+function splittypedef(ex)
+    ex = MacroTools.striplines(ex)
+    d = Dict{Symbol, Any}()
+    if @capture(ex, struct header_ body__ end)
+        d[:mutable] = false
+    elseif @capture(ex, mutable struct header_ body__ end)
+        d[:mutable] = true
+    else
+        parse_error(ex)
+    end
+    
+    if @capture header nameparam_ <: super_
+        nothing
+    elseif @capture header nameparam_
+        super = :Any
+    else
+        parse_error(ex)
+    end
+    d[:supertype] = super
+    if @capture nameparam name_{param__}
+        nothing
+    elseif @capture nameparam name_
+        param = []
+    else
+        parse_error(ex)
+    end
+    d[:name] = name
+    d[:params] = param
+    d[:fields] = []
+    d[:constructors] = []
+    for item in body
+        if @capture item field_::T_
+            push!(d[:fields], (field, T))
+        elseif item isa Symbol
+            push!(d[:fields], (item, Any))
+        else
+            push!(d[:constructors], item)
+        end
+    end
+    d
+end
+
+function combinetypedef(d)
+    name = d[:name]
+    parameters = d[:params]
+    nameparam = isempty(parameters) ? name : :($name{$(parameters...)})
+    header = :($nameparam <: $(d[:supertype]))
+    fields = map(d[:fields]) do field
+        fieldname, typ = field
+        :($fieldname::$typ)
+    end
+    body = quote
+        $(fields...)
+        $(d[:constructors]...)
+    end
+    Expr(:type, d[:mutable], header, body)
+end
+
+function combinefield(x)
+    fieldname, T = x
+    :($fieldname::$T)
+end

--- a/src/macrotools.jl
+++ b/src/macrotools.jl
@@ -5,7 +5,17 @@ const STRUCTSYMBOL = VERSION < v"0.7-" ? :type : :struct
 function parse_error(ex)
     throw(ArgumentError("Cannot parse typedefinition from $ex."))
 end
-    
+
+function statements(ex)
+    exprs = []
+    if isexpr(ex, :block)
+        append!(exprs, vcat(map(statements, ex.args)...))
+    else
+        push!(exprs, ex)
+    end
+    return exprs
+end
+
 function splittypedef(ex)
     ex = MacroTools.striplines(ex)
     d = Dict{Symbol, Any}()
@@ -42,7 +52,7 @@ function splittypedef(ex)
         elseif item isa Symbol
             push!(d[:fields], (item, Any))
         else
-            push!(d[:constructors], item)
+            append!(d[:constructors], statements(item))
         end
     end
     d

--- a/src/settable.jl
+++ b/src/settable.jl
@@ -1,0 +1,35 @@
+export @settable
+using MacroTools: prewalk, splitdef, combinedef
+macro settable(ex)
+    esc(settable(ex))
+end
+
+function default_constructor_dict(dtype::Dict)
+    fieldsymbols = map(first, dtype[:fields])
+    body = splitdef(first(dtype[:constructors]))[:body]
+    Dict(:params => dtype[:params],
+    :body => body,
+    :name => dtype[:name],
+    :whereparams => dtype[:params],
+    :args => map(combinefield, dtype[:fields]),
+    :kwargs => [],
+    # :rtype => dtype[:name]
+    )
+end
+function default_constructor(dtype::Dict)
+    combinedef(default_constructor_dict(dtype))
+end
+function settable(ex)
+    dtype = splittypedef(ex)
+    isempty(dtype[:constructors]) && return ex
+    M = current_module()
+    ex = macroexpand(M, ex)
+    dtype = splittypedef(ex)
+    
+    push!(dtype[:constructors], default_constructor(dtype))
+    typedef = combinetypedef(dtype)
+    quote
+        $typedef
+    end
+end
+

--- a/src/settable.jl
+++ b/src/settable.jl
@@ -4,32 +4,72 @@ macro settable(ex)
     esc(settable(ex))
 end
 
-function default_constructor_dict(dtype::Dict)
-    fieldsymbols = map(first, dtype[:fields])
-    body = splitdef(first(dtype[:constructors]))[:body]
-    Dict(:params => dtype[:params],
-    :body => body,
-    :name => dtype[:name],
-    :whereparams => dtype[:params],
-    :args => map(combinefield, dtype[:fields]),
-    :kwargs => [],
-    # :rtype => dtype[:name]
-    )
+argsymbol(s::Symbol) = s
+
+function argsymbol(ex::Expr)::Symbol
+    if isexpr(ex, :(::))
+        return argsymbol(ex.args[1])
+    elseif isexpr(ex, :kw)
+        return argsymbol(ex.args[1])
+    else
+        error("Unsupported expression: $(ex)")
+    end
 end
-function default_constructor(dtype::Dict)
-    combinedef(default_constructor_dict(dtype))
+
+function has_posonly_constructor(dtype::Dict)
+    fields = map(first, dtype[:fields])
+    for constructor in dtype[:constructors]
+        args = map(argsymbol, splitdef(constructor)[:args])
+        if args == fields
+            return true
+        end
+    end
+    return false
 end
+
+function posonly_constructor_dict(dtype::Dict)
+    fields = map(first, dtype[:fields])
+    for constructor in dtype[:constructors]
+        def = splitdef(constructor)
+        args = map(argsymbol, def[:args])
+        kwargs = map(argsymbol, def[:kwargs])
+        if fields[1:length(args)] == args &&
+                Set(fields[length(args)+1:end]) <= Set(kwargs)
+            newargs = copy(def[:args])
+            newkwargs = []
+            for a in def[:kwargs]
+                if argsymbol(a) in fields
+                    push!(newargs, a)
+                else
+                    push!(newkwargs, a)
+                end
+            end
+            return Dict(def...,
+                        :args => newargs,
+                        :kwargs => newkwargs)
+        end
+    end
+    error("""
+          There is no appropriate inner constructor.  At least one
+          constructor has to have positional or keyword arguments with
+          name matching with the struct fields.
+          """)
+end
+
+function posonly_constructor(dtype::Dict)
+    combinedef(posonly_constructor_dict(dtype))
+end
+
 function settable(ex)
     dtype = splittypedef(ex)
     isempty(dtype[:constructors]) && return ex
     M = current_module()
     ex = macroexpand(M, ex)
     dtype = splittypedef(ex)
-    
-    push!(dtype[:constructors], default_constructor(dtype))
-    typedef = combinetypedef(dtype)
-    quote
-        $typedef
+    if has_posonly_constructor(dtype)
+        return ex
+    else
+        push!(dtype[:constructors], posonly_constructor(dtype))
+        return combinetypedef(dtype)
     end
 end
-

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+StaticArrays

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 StaticArrays
 QuickTypes
+Reconstructables

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 StaticArrays
+QuickTypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,9 @@ using Setfield
 import Setfield: @focus
 using Base.Test
 
+include("test_macrotools.jl")
+include("test_settable.jl")
+
 struct T
     a
     b
@@ -139,6 +142,7 @@ end
           ((@lens _.b.a         ),   o21),
           ((@lens _.b.a.b[2]    ),   4  ),
           ((@lens _             ),   obj),
+          ((@lens _             ),   :xy),
         ]
         @inferred get(lens, obj)
         @inferred set(lens, obj, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,12 +223,7 @@ Setfield.constructor_of(::Type{<: B{T}}) where T = B{T}
     @test obj2 === B{1}(2, :three)
 end
 
-@static if Pkg.installed("StaticArrays") != nothing
-    using StaticArrays
-    obj = StaticArrays.@SMatrix [1 2; 3 4]
-    l = @lens _[2,1]
-    @test get(l, obj) == 3
-    @test_broken set(l, obj, 5) == StaticArrays.@SMatrix [1 2; 5 4]
-    @test_broken setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
+if Pkg.installed("StaticArrays") != nothing
+    include("test_staticarrays.jl")
     include("spaceship.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,6 +198,17 @@ end
     @test m.a === m_inner_init
 end
 
+struct A{X, Y}
+    x::X
+    y::Y
+end
+
+@testset "type change during @set (default constructor_of)" begin
+    obj = A(2,3)
+    obj2 = @set obj.y = :three
+    @test obj2 === A(2, :three)
+end
+
 # https://github.com/tkf/Reconstructables.jl#how-to-use-type-parameters
 struct B{T, X, Y}
     x::X
@@ -206,7 +217,7 @@ struct B{T, X, Y}
 end
 Setfield.constructor_of(::Type{<: B{T}}) where T = B{T}
 
-@testset "type change during @set" begin
+@testset "type change during @set (custom constructor_of)" begin
     obj = B{1}(2,3)
     obj2 = @set obj.y = :three
     @test obj2 === B{1}(2, :three)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,4 +234,8 @@ if Pkg.installed("QuickTypes") != nothing
     @testset "QuickTypes" begin include("test_quicktypes.jl") end
 end
 
+if Pkg.installed("Reconstructables") != nothing
+    @testset "KwOnly" begin include("test_kwonly.jl") end
+end
+
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,4 +230,8 @@ if Pkg.installed("StaticArrays") != nothing
     include("spaceship.jl")
 end
 
+if Pkg.installed("QuickTypes") != nothing
+    @testset "QuickTypes" begin include("test_quicktypes.jl") end
+end
+
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+module TestSetfield
+
 using Setfield
 import Setfield: @focus
 using Base.Test
@@ -227,3 +229,5 @@ if Pkg.installed("StaticArrays") != nothing
     include("test_staticarrays.jl")
     include("spaceship.jl")
 end
+
+end  # module

--- a/test/test_kwonly.jl
+++ b/test/test_kwonly.jl
@@ -1,0 +1,21 @@
+module TestKwonly
+
+using Base.Test
+using Setfield
+using Reconstructables: @add_kwonly
+
+@settable struct A
+    x
+    y
+    @add_kwonly A(x; y=2) = new(x, y)
+end
+
+x0 = A(A(A(5), A(6, 7)))
+x1 = @set x0.x.x.x = 10
+x2 = @set x1.x.y.y = 20
+
+@test x2.x.x.x == 10
+@test x2.x.y.y == 20
+@test x2.x.y.x == x0.x.y.x == 6
+
+end  # module

--- a/test/test_macrotools.jl
+++ b/test/test_macrotools.jl
@@ -1,0 +1,44 @@
+using MacroTools
+using Setfield: splittypedef, combinetypedef
+
+@testset "combinetypedef, splittypedef" begin
+    ex = :(struct S end)
+    @test ex |> splittypedef |> combinetypedef |> Base.remove_linenums! == 
+        :(struct S <: Any end)
+    
+    @test splittypedef(ex) == Dict(
+        :constructors => Any[],
+        :mutable => false,
+        :params => Any[],
+        :name => :S,
+        :fields => Any[],
+        :supertype => :Any)
+
+    ex = :(mutable struct T end)
+    @test splittypedef(ex)[:mutable] === true
+    @test ex |> splittypedef |> combinetypedef |> Base.remove_linenums! == 
+        :(mutable struct T <: Any end)
+
+    ex = :(struct S{A,B} <: AbstractS{B}
+                               a::A
+                           end)
+    @test splittypedef(ex) == Dict(
+        :constructors => Any[],
+        :mutable => false,
+        :params => Any[:A, :B],
+        :name => :S,
+        :fields => Any[(:a, :A)],
+        :supertype => :(AbstractS{B}),)
+
+    @test ex |> splittypedef |> combinetypedef |> Base.remove_linenums! == 
+        ex |> Base.remove_linenums!
+
+    ex = :(struct S{A} <: Foo; S(a::A) where {A} = new{A}() end)
+    @test ex |> splittypedef |> combinetypedef |> Base.remove_linenums! == 
+        ex |> Base.remove_linenums!
+
+    constructors = splittypedef(ex)[:constructors]
+    @test length(constructors) == 1
+    @test first(constructors) == :((S(a::A) where A) = new{A}())
+
+end

--- a/test/test_macrotools.jl
+++ b/test/test_macrotools.jl
@@ -34,11 +34,13 @@ using Setfield: splittypedef, combinetypedef
         ex |> Base.remove_linenums!
 
     ex = :(struct S{A} <: Foo; S(a::A) where {A} = new{A}() end)
-    @test ex |> splittypedef |> combinetypedef |> Base.remove_linenums! == 
-        ex |> Base.remove_linenums!
+    @test ex |> splittypedef |> combinetypedef |>
+        Base.remove_linenums! |> MacroTools.flatten ==
+        ex |> Base.remove_linenums! |> MacroTools.flatten
 
     constructors = splittypedef(ex)[:constructors]
     @test length(constructors) == 1
-    @test first(constructors) == :((S(a::A) where A) = new{A}())
+    @test first(constructors) ==
+        :((S(a::A) where A) = new{A}()) |> MacroTools.flatten
 
 end

--- a/test/test_quicktypes.jl
+++ b/test/test_quicktypes.jl
@@ -1,0 +1,124 @@
+module TestQuicktypes
+import Base: ==
+using Base.Test
+
+using QuickTypes
+using Setfield
+
+# Examples are taken from https://github.com/cstjean/QuickTypes.jl
+# Strings are replaced with symbols so that `===` and `==` works
+# nicely.
+
+@qstruct Wall(width, height)
+
+@testset "Wall" begin
+    x0 = Wall(400, 600)
+    x1 = @set x0.width = 300
+    @test x1 === Wall(300, 600)
+end
+
+
+@settable @qstruct Cat(name, age::Int, nlegs=4; species=:Siamese)
+
+@testset "Cat" begin
+    x0 = Cat(:Tama, 1)
+
+    x1 = @set x0.nlegs = 8
+    @test x1 === Cat(:Tama, 1, 8)
+
+    x2 = @set x0.species = :Singapura
+    @test x2 === Cat(:Tama, 1, species=:Singapura)
+end
+
+
+@qstruct Pack{T}(animals::Vector{T})
+
+@testset "Pack" begin
+    x0 = Pack([Cat(:Tama, 1), Cat(:Pochi, 2)])
+
+    x1 = @set x0.animals[2].nlegs = 5
+    @test x1.animals == [Cat(:Tama, 1), Cat(:Pochi, 2, 5)]
+end
+
+
+abstract type Tree end
+@qstruct Maple(qty_syrup::Float64) <: Tree
+
+@testset "Maple" begin
+    x0 = Maple(1)
+    x1 = @set x0.qty_syrup = 2
+    @test x1 === Maple(2)
+end
+
+
+@qmutable Window(height::Float64, width::Float64)
+==(x::Window, y::Window) = x.height == y.height && x.width == y.width
+
+@testset "Window" begin
+    x0 = Window(1, 2)
+
+    x1 = @set x0.width = 3.0
+    @test isequal(x1, Window(1, 3))
+    @test x1 == Window(1, 3)
+
+    @test_broken @set x0.width = 3
+end
+
+
+# Change the example to use keyword arguments, to make it non-trivial
+# for @settable:
+@settable @qstruct Human(; name=:Alice, height::Float64=170) do
+    @assert height > 0    # arbitrary code, executed in the constructor
+end
+
+@testset "Human" begin
+    x0 = Human()
+
+    x1 = @set x0.name = :Bob
+    @test x1 === Human(name=:Bob)
+
+    @test_throws AssertionError @set x0.height = -10
+end
+
+
+@qstruct Group{x}(members::x; _concise_show=true)
+
+@testset "Group" begin
+    x0 = Group([0, 1])
+
+    x1 = @set x0.members[2] = 111
+    @test x1.members == [0, 111]
+end
+
+
+# QuickTypes generates inner constructor with type parameters
+# (something like "Plane{T1,T2,T3}(nwheels::T1, weight::T2;
+# brand::T3)").  So, constructor_of needs to get a constructor with
+# all type parameters.
+@settable @qstruct_fp Plane1(nwheels, weight::Number; brand=:zoomba)
+Setfield.constructor_of(::Type{T}) where {T <: Plane1} = T
+
+@testset "Plane1" begin
+    x0 = Plane1(3, 100)
+
+    x1 = @set x0.nwheels = 5
+    @test x1 == Plane1(5, 100)
+
+    # Changing type parameter is not possible:
+    @test_throws MethodError @set x0.brand = 31
+end
+
+# Another way to "support" QuickTypes with type parameters is to use
+# QuickTypes.construct.
+@qstruct_fp Plane2(nwheels, weight::Number; brand=:zoomba)
+Setfield.constructor_of(::Type{<: Plane2}) =
+    (args...) -> QuickTypes.construct(Plane2, args...)
+
+@testset "Plane2" begin
+    x0 = Plane2(3, 100)
+
+    x1 = @set x0.brand = 31
+    @test x1 == Plane2(3, 100, brand=31)
+end
+
+end  # module

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -62,3 +62,23 @@ Setfield.constructor_of(::Type{<: UntypedConstructor}) = UntypedConstructor
     @test s2 === UntypedConstructor(1, b=-2)
     @test_throws AssertionError @set s1.b = 2
 end
+
+# @settable must (1) choose a correct constructor for generating
+# positional-only constructor and (2) do so without overriding
+# existing constructor.
+# https://github.com/jw3126/Setfield.jl/pull/18#discussion_r172649307
+@settable struct ManyConstructors
+    a
+    b
+    ManyConstructors(a; b=2) = new(a, b)
+    ManyConstructors(a) = new(a, 1)  # must not be overridden
+end
+
+@testset "ManyConstructors" begin
+    # The single-argument constructor must be the one defined by user.
+    @test ManyConstructors(0) === ManyConstructors(0, b=1)
+
+    s1 = ManyConstructors(0)
+    s2 = @set s1.b = -2
+    @test s2 === ManyConstructors(0, b=-2)
+end

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -82,3 +82,21 @@ end
     s2 = @set s1.b = -2
     @test s2 === ManyConstructors(0, b=-2)
 end
+
+# Mimic @add_kwonly from Reconstructables.jl and DiffEqBase.jl.
+@settable struct WithKwOnly
+    a
+    b
+    WithKwOnly(a; b=2) = new(a, b)
+    WithKwOnly(; a=error("`a` is mandatory"), b=2) = new(a, b)
+end
+
+@testset "WithKwOnly" begin
+    # Keyword-only constructor works:
+    @test WithKwOnly(0) === WithKwOnly(a=0)
+    @test_throws ErrorException WithKwOnly()
+
+    s1 = WithKwOnly(0)
+    s2 = @set s1.b = -2
+    @test s2 === WithKwOnly(0, b=-2)
+end

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -4,6 +4,7 @@
 @settable struct NoConstructor{A,B}
     b::B
 end
+Setfield.constructor_of(::Type{T}) where {T <: NoConstructor} = T
 
 @testset "NoConstructor" begin
     s1 = NoConstructor{:a,Int}(1)
@@ -17,6 +18,7 @@ end
     b::B
     ExplicitConstructor{A,B}(b::B) where {A,B} = new{A,B}(b)
 end
+Setfield.constructor_of(::Type{T}) where {T <: ExplicitConstructor} = T
 
 @testset "ExplicitConstructor" begin
     s1 = ExplicitConstructor{:a,Int}(1)
@@ -36,6 +38,7 @@ end
         return new{A,B}(a, b)
     end
 end
+Setfield.constructor_of(::Type{T}) where {T <: TypedConstructor} = T
 
 @testset "TypedConstructor" begin
     s1 = TypedConstructor{Int,Int}(1)
@@ -54,7 +57,6 @@ end
         return new{A,B}(a, b)
     end
 end
-Setfield.constructor_of(::Type{<: UntypedConstructor}) = UntypedConstructor
 
 @testset "UntypedConstructor" begin
     s1 = UntypedConstructor(1, 0)

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -86,11 +86,17 @@ end
 end
 
 # Mimic @add_kwonly from Reconstructables.jl and DiffEqBase.jl.
+macro kwonly()
+    esc(quote
+        WithKwOnly(a; b=2) = new(a, b)
+        WithKwOnly(; a=error("`a` is mandatory"), b=2) = new(a, b)
+        end)
+end
+
 @settable struct WithKwOnly
     a
     b
-    WithKwOnly(a; b=2) = new(a, b)
-    WithKwOnly(; a=error("`a` is mandatory"), b=2) = new(a, b)
+    @kwonly
 end
 
 @testset "WithKwOnly" begin

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -1,0 +1,10 @@
+@settable struct SetMe{A,B}
+    b::B
+    SetMe{A}(b::B) where {A,B} = new{A,B}(b)
+end
+
+@testset "settable" begin
+    s1 = SetMe{:a}(1)
+    s2 = @set s1.b = 2
+    @test s2 === SetMe{:a,Int64}(2)
+end

--- a/test/test_settable.jl
+++ b/test/test_settable.jl
@@ -1,10 +1,64 @@
-@settable struct SetMe{A,B}
+# If no constructor is defined explicitly, don't generate any
+# inner-consturctor; let Julia generate the default constructor; i.e.,
+# @settable should be a no-op.
+@settable struct NoConstructor{A,B}
     b::B
-    SetMe{A}(b::B) where {A,B} = new{A,B}(b)
 end
 
-@testset "settable" begin
-    s1 = SetMe{:a}(1)
+@testset "NoConstructor" begin
+    s1 = NoConstructor{:a,Int}(1)
     s2 = @set s1.b = 2
-    @test s2 === SetMe{:a,Int64}(2)
+    @test s2 === NoConstructor{:a,Int}(2)
+end
+
+# If the position-only constructor is defined explicitly, don't
+# generate any inner-consturctor; i.e., @settable should be a no-op.
+@settable struct ExplicitConstructor{A,B}
+    b::B
+    ExplicitConstructor{A,B}(b::B) where {A,B} = new{A,B}(b)
+end
+
+@testset "ExplicitConstructor" begin
+    s1 = ExplicitConstructor{:a,Int}(1)
+    s2 = @set s1.b = 2
+    @test s2 === ExplicitConstructor{:a,Int}(2)
+end
+
+# If non- position-only constructor is given, generate the
+# position-only constructor from it.
+@settable struct TypedConstructor{A,B}
+    a::A
+    b::B
+    function TypedConstructor{A,B}(a::A; b::B=0) where {A,B}
+        # This assertion has to be executed in the generated inner
+        # constructor as well:
+        @assert a > b
+        return new{A,B}(a, b)
+    end
+end
+
+@testset "TypedConstructor" begin
+    s1 = TypedConstructor{Int,Int}(1)
+    s2 = @set s1.b = -2
+    @test s2 === TypedConstructor{Int,Int}(1,-2)
+    @test_throws AssertionError @set s1.b = 2
+end
+
+@settable struct UntypedConstructor{A,B}
+    a::A
+    b::B
+    function UntypedConstructor(a::A; b::B=0) where {A,B}
+        # This assertion has to be executed in the generated inner
+        # constructor as well:
+        @assert a > b
+        return new{A,B}(a, b)
+    end
+end
+Setfield.constructor_of(::Type{<: UntypedConstructor}) = UntypedConstructor
+
+@testset "UntypedConstructor" begin
+    s1 = UntypedConstructor(1, 0)
+    s2 = @set s1.b = -2
+    @test s2 === UntypedConstructor(1, b=-2)
+    @test_throws AssertionError @set s1.b = 2
 end

--- a/test/test_staticarrays.jl
+++ b/test/test_staticarrays.jl
@@ -1,0 +1,7 @@
+using StaticArrays
+
+obj = StaticArrays.@SMatrix [1 2; 3 4]
+l = @lens _[2,1]
+@test get(l, obj) == 3
+@test_broken set(l, obj, 5) == StaticArrays.@SMatrix [1 2; 5 4]
+@test_broken setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]


### PR DESCRIPTION
- [x] merge #17 to master
- [ ] then rebase onto master
- [ ] use Kwonly.jl instead of Reconstructables.jl for `@add_kwonly` test, once https://github.com/JuliaLang/METADATA.jl/pull/13769 is merged

Not sure we want to actually merge this.  It's just for start discussing interoperability with other packages, especially QuickTypes.jl.
