### PR TITLE
Fix test_staticarrays.jl

### DIFF
--- a/test/test_staticarrays.jl
+++ b/test/test_staticarrays.jl
@@ -3,8 +3,8 @@ using StaticArrays
 obj = StaticArrays.@SMatrix [1 2; 3 4]
 l = @lens _[2,1]
 @test get(l, obj) == 3
-@test_broken set(l, obj, 5) == StaticArrays.@SMatrix [1 2; 5 4]
-@test_broken setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
+@test set(l, obj, 5) == StaticArrays.@SMatrix [1 2; 5 4]
+@test setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
 
 v = @SVector [1,2,3]
 @test (@set v[1] = 10) === @SVector [10,2,3]


### PR DESCRIPTION
It looks like StaticArrays.jl v0.7.1 was released before merging #31 :)
https://github.com/JuliaArrays/StaticArrays.jl/releases/tag/v0.7.1

Probably that's why the PR tests were fine but the latest build failed.