### PR TITLE
Fix IndexLens for mutable arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ git:
 #before_script: # homebrew for mac
 #  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
-# uncomment the following lines to override the default test script
-script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Setfield"); VERSION < v"0.7-" && Pkg.add("StaticArrays"); Pkg.test("Setfield"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ git:
 
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("Setfield")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; cd(Pkg.dir("Setfield")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; cd(Pkg.dir("Setfield")); include(joinpath("docs", "make.jl"))'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,8 @@ end
     include("test_kwonly.jl")
 end
 
-@static if VERSION < v"0.7-"
 @testset "QuickTypes.jl" begin
     include("test_quicktypes.jl")
-end
 end
 
 end  # module


### PR DESCRIPTION
This is alternative to #39.  If we want to handle mutable arrays (such as `Array`) by always copying them, this PR provides an implementation for it.  This is consistent with how `nomut` branch handles `mutable struct`.