### PR TITLE
Use one tesetset for each performance test setup

### DIFF
--- a/test/perf.jl
+++ b/test/perf.jl
@@ -112,10 +112,10 @@ function test_ir_lens_vs_hand(info_lens::Core.CodeInfo,
     @test uniquecounts(heads_lens) == uniquecounts(heads_hand)
 end
 
-@testset "benchmark" begin
+let
     obj = AB(AB(1,2), :b)
     val = (1,2)
-    for setup in [
+    @testset "$(setup.lens)" for setup in [
             (lens=lens_set_a,           hand=hand_set_a,       args=(obj, val)),
             (lens=lens_set_a,           hand=hand_set_a,       args=(obj, val)),
             (lens=lens_set_ab,          hand=hand_set_ab,      args=(obj, val)),
@@ -129,13 +129,16 @@ end
 
         @assert f_hand(args) == f_lens(args)
 
-        b_lens = @benchmarkable $f_lens($args)
-        b_hand = @benchmarkable $f_hand($args)
-        benchmark_lens_vs_hand(b_lens, b_hand)
+        @testset "benchmark" begin
+            b_lens = @benchmarkable $f_lens($args)
+            b_hand = @benchmarkable $f_hand($args)
+            benchmark_lens_vs_hand(b_lens, b_hand)
+        end
 
-
-        info_lens, _ = @code_typed f_lens(args)
-        info_hand, _ = @code_typed f_hand(args)
-        test_ir_lens_vs_hand(info_lens, info_hand)
+        @testset "IR" begin
+            info_lens, _ = @code_typed f_lens(args)
+            info_hand, _ = @code_typed f_hand(args)
+            test_ir_lens_vs_hand(info_lens, info_hand)
+        end
     end
 end


### PR DESCRIPTION
Since we'll need to compare benchmark and IR test results if at least one of them fails, I suggest to wrap each tests with `@testset`.  When the test fails, it will produces something like

```
Test Summary:      | Pass  Fail  Total
test set           |   20     5     25
  lens_set_a       |    4     1      5
    benchmark      |    1     1      2
    IR             |    3            3
  lens_set_a       |    4     1      5
    benchmark      |    1     1      2
    IR             |    3            3
  lens_set_ab      |    4     1      5
    benchmark      |    1     1      2
    IR             |    3            3
  lens_set_a_and_b |    4     1      5
    benchmark      |    1     1      2
    IR             |    3            3
  lens_set_i       |    4     1      5
    benchmark      |    1     1      2
    IR             |    3            3
ERROR: Some tests did not pass: 20 passed, 5 failed, 0 errored, 0 broken.
```

Ideally, we'd like to see the benchmark is failing iff IR is failing.  I think we need something like this patch to correlate those failings since line numbers are useless when the tests are in the for loop.

Side notes: You need to run the tests by `include("test/runtests.jl")` or `@testset begin include("test/perf.jl") end`. Using `include("test/perf.jl")` stops the test at the first failure.

Side notes (2): Above example was generated by injecting the failures by:

```diff
diff --git a/test/perf.jl b/test/perf.jl
index aeab0b0..4fdf8bd 100644
--- a/test/perf.jl
+++ b/test/perf.jl
@@ -133,6 +133,7 @@ let
             b_lens = @benchmarkable $f_lens($args)
             b_hand = @benchmarkable $f_hand($args)
             benchmark_lens_vs_hand(b_lens, b_hand)
+            @test false
         end

         @testset "IR" begin
```