### PR TITLE
Run performance tests in a subprocess

### DIFF
--- a/test/perf.jl
+++ b/test/perf.jl
@@ -112,7 +112,7 @@ function test_ir_lens_vs_hand(info_lens::Core.CodeInfo,
     @test uniquecounts(heads_lens) == uniquecounts(heads_hand)
 end
 
-let
+@testset begin
     obj = AB(AB(1,2), :b)
     val = (1,2)
     @testset "$(setup.lens)" for setup in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,16 @@ using Test
 using Setfield
 
 @testset "Performance" begin
-    include("perf.jl")
+    script = joinpath(@__DIR__, "perf.jl")
+    cmd = ```
+        $(Base.julia_cmd())
+        --color=$(Base.have_color ? "yes" : "no")
+        --startup-file=no
+        --check-bounds=no
+        -O3
+        $script
+    ```
+    @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
 end
 
 @testset "core" begin


### PR DESCRIPTION
`Pkg.test` sets `--code-coverage` etc.: https://github.com/JuliaLang/Pkg.jl/blob/d123b48e63b5a5e09cb224c6385a3f512627e4ac/src/Operations.jl#L1311-L1320

So maybe running benchmarks in subprocess helps?