### PR TITLE
Make sure show(::MultiPropertyLens) does not throw

### DIFF
--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -35,4 +35,10 @@ end
         Expr(:call, :(constructor_of($T)), args...)
     )
 end
+
+function Base.show(io::IO, l::MultiPropertyLens)
+    print(io, "MultiPropertyLens(")
+    print(io, l.lenses)
+    print(io, ')')
+end
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -71,6 +71,8 @@ end
             @lens _[1]
             @lens _.a.b[2]
             @lens _
+            MultiPropertyLens((a=@lens(_),))
+            (@lens _.a[1]) ∘ MultiPropertyLens((b = (@lens _[1]),))
         ]
         buf = IOBuffer()
         show(buf, item)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -63,6 +63,9 @@ end
 end
 
 
+struct UserDefinedLens <: Lens end
+
+
 @testset "show it like you build it " begin
     obj = T(1,2)
     i = 3
@@ -73,6 +76,10 @@ end
             @lens _
             MultiPropertyLens((a=@lens(_),))
             (@lens _.a[1]) ∘ MultiPropertyLens((b = (@lens _[1]),))
+            UserDefinedLens()
+            (@lens _.a) ∘ UserDefinedLens()
+            UserDefinedLens() ∘ (@lens _.b)
+            (@lens _.a) ∘ UserDefinedLens() ∘ (@lens _.b)
         ]
         buf = IOBuffer()
         show(buf, item)


### PR DESCRIPTION
Something I noticed while #51. To be rebased after #51 is merged. It's just one commit: 1284a47e10c7ef3d1085f6497b1153ab1fbf8191