### PR TITLE
Add ConstIndexLens for type-stable indexing of tuples

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -20,7 +20,7 @@ julia> s = SpaceShip(Person(:julia, 2009), [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
 SpaceShip(Person(:julia, 2009), [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
 ```
 Lets update the captains name:
-```jldoctest spaceship
+```jldoctest spaceship; filter = r" .*$"
 julia> s.captain.name = :JULIA
 ERROR: type Person is immutable
 ```

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -203,6 +203,57 @@ Base.@propagate_inbounds function set(obj, l::IndexLens, val)
     setindex(obj, val, l.indices...)
 end
 
+"""
+    ConstIndexLens{I}
+
+Lens with index stored in type parameter.  This is useful for type-stable
+[`get`](@ref) and [`set`](@ref) operations on tuples and named tuples.
+
+This lens can be constructed by, e.g., `@lens _[\$1]`.  Complex expression
+must be wrapped with `\$(...)` like `@lens _[\$(length(xs))]`.
+
+# Examples
+```jldoctest
+julia> using Setfield
+
+julia> get((1, 2.0), @lens _[\$1])
+1
+
+julia> Base.promote_op(get, typeof.(((1, 2.0), @lens _[\$1]))...)
+Int64
+
+julia> Base.promote_op(get, typeof.(((1, 2.0), @lens _[1]))...)
+Union{Float64, Int64}
+```
+"""
+struct ConstIndexLens{I} <: Lens end
+
+Base.@propagate_inbounds get(obj, ::ConstIndexLens{I}) where I = obj[I...]
+
+Base.@propagate_inbounds set(obj, ::ConstIndexLens{I}, val) where I =
+    setindex(obj, val, I...)
+
+@generated function set(obj::Union{Tuple, NamedTuple},
+                        ::ConstIndexLens{I},
+                        val) where I
+    if length(I) == 1
+        n, = I
+        args = map(1:length(obj.types)) do i
+            i == n ? :val : :(obj[$i])
+        end
+        quote
+            $(Expr(:meta, :inline))
+            ($(args...),)
+        end
+    else
+        quote
+            throw(ArgumentError($(string(
+                "A `Tuple` and `NamedTuple` can only be indexed with one ",
+                "integer.  Given: $I"))))
+        end
+    end
+end
+
 Base.@deprecate get(lens::Lens, obj)       get(obj, lens)
 Base.@deprecate set(lens::Lens, obj, val)  set(obj, lens, val)
 Base.@deprecate modify(f, lens::Lens, obj) modify(f, obj, lens)

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -222,8 +222,8 @@ julia> get((1, 2.0), @lens _[\$1])
 julia> Base.promote_op(get, typeof.(((1, 2.0), @lens _[\$1]))...)
 Int64
 
-julia> Base.promote_op(get, typeof.(((1, 2.0), @lens _[1]))...)
-Union{Float64, Int64}
+julia> Base.promote_op(get, typeof.(((1, 2.0), @lens _[1]))...) !== Int
+true
 ```
 """
 struct ConstIndexLens{I} <: Lens end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -105,6 +105,12 @@ end
     si = @set t.a[i] = 10
     @test s1 === si
 
+    s1 = @set t.a[$1] = 10
+    @test s1 === T((10,2),(3,4))
+    i = 1
+    si = @set t.a[$i] = 10
+    @test s1 === si
+
     t = @set T(1,2).a = 2
     @test t === T(2,2)
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -119,7 +119,9 @@ struct UserDefinedLens <: Lens end
     for item in [
             @lens _.a
             @lens _[1]
-            @lens _.a.b[2]
+            @lens _[$1]
+            @lens _[$1, $(1 + 1)]
+            @lens _.a.b[2][$3]
             @lens _
             MultiPropertyLens((a=@lens(_),))
             (@lens _.a[1]) ∘ MultiPropertyLens((b = (@lens _[1]),))
@@ -168,6 +170,8 @@ end
             @lens _.b.a
             @lens _.b.a.b[2]
             @lens _.b.a.b[i]
+            @lens _.b.a.b[$2]
+            @lens _.b.a.b[$i]
             @lens _
         ]
         val1, val2 = randn(2)
@@ -199,6 +203,10 @@ end
           ((@lens _.b.a         ),   o21),
           ((@lens _.b.a.b[2]    ),   4  ),
           ((@lens _.b.a.b[i+1]  ),   4  ),
+          ((@lens _.b.a.b[$2]   ),   4  ),
+          ((@lens _.b.a.b[$(i+1)]),  4  ),
+          ((@lens _.b.a.b[$2]   ),   4.0),
+          ((@lens _.b.a.b[$(i+1)]),  4.0),
           ((@lens _             ),   obj),
           ((@lens _             ),   :xy),
           (MultiPropertyLens((a=(@lens _), b=(@lens _))), (a=1, b=2)),
@@ -227,6 +235,23 @@ end
 
 
     l = @lens _[1:3]
+    @test get([4,5,6,7], l) == [4,5,6]
+end
+
+@testset "ConstIndexLens" begin
+    obj = (1, 2.0, '3')
+    l = @lens _[$1]
+    @test (@inferred get(obj, l)) === 1
+    @test (@inferred set(obj, l, 6.0)) === (6.0, 2.0, '3')
+    l = @lens _[$(1 + 1)]
+    @test (@inferred get(obj, l)) === 2.0
+    @test (@inferred set(obj, l, 6)) === (1, 6, '3')
+    n = 1
+    l = @lens _[$(3n)]
+    @test (@inferred get(obj, l)) === '3'
+    @test (@inferred set(obj, l, 6)) === (1, 2.0, 6)
+
+    l = @lens _[$(1:3)]
     @test get([4,5,6,7], l) == [4,5,6]
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -259,6 +259,26 @@ end
 
     l = @lens _[$(1:3)]
     @test get([4,5,6,7], l) == [4,5,6]
+
+    @testset "complex example (sweeper)" begin
+        sweeper_with_const = (
+            model = (1, 2.0, 3im),
+            axis = (@lens _[$2]),
+        )
+
+        sweeper_with_noconst = @set sweeper_with_const.axis = @lens _[2]
+
+        function f(s)
+            a = sum(set(s.model, s.axis, 0))
+            for i in 1:10
+                a += sum(set(s.model, s.axis, i))
+            end
+            return a
+        end
+
+        @test (@inferred f(sweeper_with_const)) == 66 + 33im
+        @test_broken (@inferred f(sweeper_with_noconst)) == 66 + 33im
+    end
 end
 
 mutable struct M

--- a/test/test_staticarrays.jl
+++ b/test/test_staticarrays.jl
@@ -5,10 +5,14 @@ using StaticArrays
 
 @testset "StaticArrays" begin
     obj = StaticArrays.@SMatrix [1 2; 3 4]
-    l = @lens _[2,1]
-    @test get(obj, l) == 3
-    @test set(obj, l, 5) == StaticArrays.@SMatrix [1 2; 5 4]
-    @test setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
+    @testset for l in [
+            (@lens _[2,1]),
+            (@lens _[$2,$1]),
+        ]
+        @test get(obj, l) == 3
+        @test set(obj, l, 5) == StaticArrays.@SMatrix [1 2; 5 4]
+        @test setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
+    end
 
     v = @SVector [1,2,3]
     @test (@set v[1] = 10) === @SVector [10,2,3]


### PR DESCRIPTION
This PR adds a new lens `ConstIndexLens` constructible via `@lens _[$1]` etc.

Not sure if it should go directly to public API.  Is it better to put it in experimental?  Although the sugar `@lens _[$1]` is kind of nice to have (but then it's not possible to hide it in experimental module).

fixes #59