### PR TITLE
Fix show for IndexLens

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -170,7 +170,7 @@ has_atlens_support(l::ComposedLens) =
     has_atlens_support(l.outer) && has_atlens_support(l.inner)
 
 print_application(io::IO, l::PropertyLens{field}) where {field} = print(io, ".", field)
-print_application(io::IO, l::IndexLens) = print(io, "[", join(l.indices, ", "), "]")
+print_application(io::IO, l::IndexLens) = print(io, "[", join(repr.(l.indices), ", "), "]")
 print_application(io::IO, ::ConstIndexLens{I}) where I =
     print(io, "[", join(string.("\$", I), ", "), "]")
 print_application(io::IO, l::IdentityLens) = print(io, "")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -120,14 +120,15 @@ struct UserDefinedLens <: Lens end
 
 
 @testset "show it like you build it " begin
-    obj = T(1,2)
     i = 3
-    for item in [
+    @testset for item in [
             @lens _.a
             @lens _[1]
+            @lens _[:a]
+            @lens _["a"]
             @lens _[$1]
             @lens _[$1, $(1 + 1)]
-            @lens _.a.b[2][$3]
+            @lens _.a.b[:c]["d"][2][$3]
             @lens _
             MultiPropertyLens((a=@lens(_),))
             (@lens _.a[1]) ∘ MultiPropertyLens((b = (@lens _[1]),))


### PR DESCRIPTION
I realized that `show` for lenses like `@lens _[:a]` and `@lens _["a"]` are not `parse`-able.  This PR fixes it simply by using `repr` when printing indices.

Before:

```julia
julia> @lens _[:a]
(@lens _[a])
```

After:

```julia
julia> @lens _[:a]
(@lens _[:a])
```
