### PR TITLE
RFC: Function as a Lens

### DIFF
--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -5,6 +5,7 @@ using MacroTools: isstructdef, splitstructdef
 
 include("lens.jl")
 include("sugar.jl")
+include("functionlenses.jl")
 include("settable.jl")
 include("experimental.jl")
 end

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -1,0 +1,2 @@
+set(obj, ::FunctionLens{last}, val) = @set obj[length(obj)] = val
+set(obj, ::FunctionLens{first}, val) = @set obj[1] = val

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -1,2 +1,14 @@
 set(obj, ::FunctionLens{last}, val) = @set obj[length(obj)] = val
 set(obj, ::FunctionLens{first}, val) = @set obj[1] = val
+
+set(obj::Array, ::FunctionLens{eltype}, T::Type) = collect(T, obj)
+set(::Type{<:Array{<:Any, N}}, ::FunctionLens{eltype}, ::Type{T}) where {N, T} =
+    Array{T, N}
+
+set(obj::Dict, l::FunctionLens, T::Type) = set(typeof(obj), l, T)(obj)
+set(::Type{<:Dict}, ::FunctionLens{eltype}, ::Type{Pair{K, V}}) where {K, V} =
+    Dict{K, V}
+set(::Type{<:Dict{<:Any,V}}, ::FunctionLens{keytype}, ::Type{K}) where {K, V} =
+    Dict{K, V}
+set(::Type{<:Dict{K}}, ::FunctionLens{valtype}, ::Type{V}) where {K, V} =
+    Dict{K, V}

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -278,6 +278,38 @@ Base.@propagate_inbounds set(obj, ::ConstIndexLens{I}, val) where I =
     end
 end
 
+"""
+    FunctionLens(f)
+
+Lens with [`get`](@ref) method definition that simply calls `f`.
+[`set`](@ref) method for each function `f` must be implemented manually.
+Use `methods(set, (Any, Setfield.FunctionLens, Any))` to get a list of
+supported functions.
+
+Note that `FunctionLens` flips the order of composition; i.e.,
+`(@lens f(_)) ∘ (@lens g(_)) == @lens g(f(_))`.
+
+# Example
+```jldoctest
+julia> using Setfield
+
+julia> obj = ((1, 2), (3, 4));
+
+julia> l = (@lens first(_)) ∘ (@lens last(_))
+(@lens last(first(_)))
+
+julia> get(obj, lens)
+3
+
+julia> set(obj, lens, '3')
+((1, 2), ('3', 4))
+```
+"""
+struct FunctionLens{f} <: Lens end
+FunctionLens(f) = FunctionLens{f}()
+
+get(obj, ::FunctionLens{f}) where f = f(obj)
+
 Base.@deprecate get(lens::Lens, obj)       get(obj, lens)
 Base.@deprecate set(lens::Lens, obj, val)  set(obj, lens, val)
 Base.@deprecate modify(f, lens::Lens, obj) modify(f, obj, lens)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 module TestSetfield
 include("test_core.jl")
+include("test_functionlenses.jl")
 include("test_settable.jl")
 include("test_staticarrays.jl")
 include("test_kwonly.jl")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -130,6 +130,9 @@ struct UserDefinedLens <: Lens end
             @lens _[$1, $(1 + 1)]
             @lens _.a.b[:c]["d"][2][$3]
             @lens _
+            @lens first(_)
+            @lens last(first(_))
+            @lens last(first(_.a))[1]
             MultiPropertyLens((a=@lens(_),))
             (@lens _.a[1]) ∘ MultiPropertyLens((b = (@lens _[1]),))
             UserDefinedLens()

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -24,4 +24,35 @@ end
     @test (@set last(obj2.a).b = '2') === (a=(1, (b='2',)), c=3)
 end
 
+@testset "eltype(::Type{<:Array})" begin
+    obj = Vector{Int}
+    obj2 = @set eltype(obj) = Float64
+    @test obj2 === Vector{Float64}
+end
+
+@testset "eltype(::Array)" begin
+    obj = [1, 2, 3]
+    obj2 = @set eltype(obj) = Float64
+    @test eltype(obj2) == Float64
+    @test obj == obj2
+end
+
+@testset "(key|val|el)type(::Type{<:Dict})" begin
+    obj = Dict{Symbol, Int}
+    @test (@set keytype(obj) = String) === Dict{String, Int}
+    @test (@set valtype(obj) = String) === Dict{Symbol, String}
+    @test (@set eltype(obj) = Pair{String, Any}) === Dict{String, Any}
+
+    obj2 = Dict{Symbol, Dict{Int, Float64}}
+    @test (@set keytype(valtype(obj2)) = String) === Dict{Symbol, Dict{String, Float64}}
+    @test (@set valtype(valtype(obj2)) = String) === Dict{Symbol, Dict{Int, String}}
+end
+
+@testset "(key|val|el)type(::Dict)" begin
+    obj = Dict(1 => 2)
+    @test typeof(@set keytype(obj) = Float64) === Dict{Float64, Int}
+    @test typeof(@set valtype(obj) = Float64) === Dict{Int, Float64}
+    @test typeof(@set eltype(obj) = Pair{UInt, Float64}) === Dict{UInt, Float64}
+end
+
 end  # module

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -1,0 +1,27 @@
+module TestFunctionLenses
+using Test
+using Setfield
+
+@testset "first" begin
+    obj = (1, 2.0, '3')
+    l = @lens first(_)
+    @test get(obj, l) === 1
+    @test set(obj, l, "1") === ("1", 2.0, '3')
+    @test (@set first(obj) = "1") === ("1", 2.0, '3')
+
+    obj2 = (a=((b=1,), 2), c=3)
+    @test (@set first(obj2.a).b = '1') === (a=((b='1',), 2), c=3)
+end
+
+@testset "last" begin
+    obj = (1, 2.0, '3')
+    l = @lens last(_)
+    @test get(obj, l) === '3'
+    @test set(obj, l, '4') === (1, 2.0, '4')
+    @test (@set last(obj) = '4') === (1, 2.0, '4')
+
+    obj2 = (a=(1, (b=2,)), c=3)
+    @test (@set last(obj2.a).b = '2') === (a=(1, (b='2',)), c=3)
+end
+
+end  # module


### PR DESCRIPTION
I propose to add a new lens `FunctionLens(f)` with a sugar `@lens f(_)`.  By default, it only has the `get` method which is defined to be:

```julia
get(x, @lens f(_)) == f(x)
```

Unlike other lenses, `FunctionLens` needs `set` method to be defined manually.

It would be useful for manipulating objects that do not have clear indexing or property access.  For example, manipulating parameterized types:

```julia
julia> obj = Vector{Int}
Array{Int64,1}

julia> @set eltype(obj) = Float32
Array{Float32,1}

julia> obj = Dict{Symbol, Dict{Int, Float64}}
Dict{Symbol,Dict{Int64,Float64}}

julia> @set keytype(valtype(obj)) = String
Dict{Symbol,Dict{String,Float64}}
```

A scary part of this proposal is that Base/stdlib methods on Base/stdlib types would be accumulated in this package to avoid type piracy.  It could bloat otherwise a slick package.  My guess/hope is that there are not too many functions with useful `FunctionLens` definition as otherwise Base/stdlib wouldn't have been usable.

I think the upside of having `@lens f(_)` is greater than the potential downside:

* It is a very nice way to expose public API for getters and setters in a composable manner.
* It works with "places" that cannot be expressed as composition of indexing and property access (e.g. type traits).

Some discussion points:

* Is it good to add this?
* Do we want all the `FunctionLens(f)` definitions I added in this PR?  They are more like demos than driven by my need.  (An example of what I want is the `FunctionLens` for [`DiffEqBase.isinplace`](https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/4392f25bcb7253e8d6205498020560db93e2368c/src/problems/problem_traits.jl#L10-L23) trait function.)  Maybe it's better to define no `set` methods and wait for someone needing it?  Alternatively we can say that those definitions are provided on a provisional basis and we need someone to open a PR/issue to stabilize the API.
* Do we want to support non-functions like callable structs?  We can use `struct FunctionLens{F}; f::F; end` instead of current `struct FunctionLens{f}; end` but we need [a bit of trick](https://github.com/tkf/Kaleido.jl/blob/c569e6e407649ab99b3bc8a76e71e9c1647415de/src/base.jl#L63-L67) to support type constructor in a dispatchable manner (as otherwise `F` would be `DataType`).
* What public overloading API should be exposed?  I think the safest option to hide all the implementation detail of `FunctionLens` and say that you need to define `set(obj::T, ::typeof(@lens myfunction(_)), x)` (i.e., rather than saying that you can use `set(obj::T, ::FunctionLens{myfunction}, x)`).
    * My thinking on this and the last points is that `typeof(@lens myfunction(_))` is a good way to go for now and supporting only functions is OK until someone needs non-functions.  `typeof(@lens myfunction(_))` would be forward compatible.
