### PR TITLE
Define constructor_of for singleton lenses

### DIFF
--- a/src/lens.jl
+++ b/src/lens.jl
@@ -324,6 +324,13 @@ FunctionLens(f) = FunctionLens{f}()
 
 get(obj, ::FunctionLens{f}) where f = f(obj)
 
+constructor_of(::Type{T}) where T <: Union{
+    # List of types that should/can not change type parameters:
+    PropertyLens,
+    ConstIndexLens,
+    FunctionLens,
+} = T
+
 Base.@deprecate get(lens::Lens, obj)       get(obj, lens)
 Base.@deprecate set(lens::Lens, obj, val)  set(obj, lens, val)
 Base.@deprecate modify(f, lens::Lens, obj) modify(f, obj, lens)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -337,6 +337,12 @@ end
     @test obj2 === TT(2, :three)
 end
 
+@testset "types that do not change parameter via constructor_of" begin
+    @test constructor_of(typeof(@lens _.a))() === @lens _.a
+    @test constructor_of(typeof(@lens _[$1]))() === @lens _[$1]
+    @test constructor_of(typeof(@lens eltype(_)))() === @lens eltype(_)
+end
+
 # https://github.com/tkf/Reconstructables.jl#how-to-use-type-parameters
 struct B{T, X, Y}
     x::X


### PR DESCRIPTION
While I'm using `constructor_of` inside [some meta-programming code](https://github.com/tkf/ChainCutters.jl/pull/8/files), I noticed that it didn't work with some lenses.  It's not necessary for Setfield.jl to work so I'm not sure if this is a good change.  But it'd make sense for Setfield.jl to have its own type `constructor_of`-compatible?

A more magic way to do this is

```julia
@generated constructor_of(::Type{T}) where T =
    if fieldcount(T) == 0
        T
    else
        getfield(parentmodule(T), nameof(T))
    end
```

Not sure if I like it though...
