### PR TITLE
Dispatch to text/plain show if defined in downstreams

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -201,21 +201,29 @@ function print_application(printer, io, l::ComposedLens)
     end
 end
 
-function Base.show(io::IO, l::Lens)
+Base.show(io::IO, l::Lens) = _show(io, nothing, l)
+Base.show(io::IO, ::MIME"text/plain", l::Lens) = _show(io, MIME("text/plain"), l)
+
+function _show(io::IO, mime, l::Lens)
     if has_atlens_support(l)
         print_in_atlens(io, l)
-    else
+    elseif mime === nothing
         show_generic(io, l)
+    else
+        # Downstream packages may define specific show for text/plain.
+        # Dispatch to their method rather than our `show_generic` in this
+        # case.
+        show(io, mime, l)
     end
 end
 
-function Base.show(io::IO, l::ComposedLens)
+function _show(io::IO, mime, l::ComposedLens)
     if has_atlens_support(l)
         print_in_atlens(io, l)
     else
-        show(io, l.outer)
+        _show(io, mime, l.outer)
         print(io, " ∘ ")
-        show(io, l.inner)
+        _show(io, mime, l.inner)
     end
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -122,6 +122,10 @@ end
 
 struct UserDefinedLens <: Lens end
 
+struct LensWithTextPlain <: Lens end
+Base.show(io::IO, ::MIME"text/plain", ::LensWithTextPlain) =
+    print(io, "I define text/plain.")
+
 
 @testset "show it like you build it " begin
     i = 3
@@ -143,6 +147,7 @@ struct UserDefinedLens <: Lens end
             (@lens _.a) ∘ UserDefinedLens()
             UserDefinedLens() ∘ (@lens _.b)
             (@lens _.a) ∘ UserDefinedLens() ∘ (@lens _.b)
+            (@lens _.a) ∘ LensWithTextPlain() ∘ (@lens _.b)
         ]
         buf = IOBuffer()
         show(buf, item)
@@ -356,6 +361,17 @@ end
     s = sprint(Setfield.show_generic,l)
     l2 = eval(Meta.parse(s))
     @test l == l2
+end
+
+@testset "text/plain show" begin
+    @testset for lens in [
+        LensWithTextPlain()
+        (@lens _.a) ∘ LensWithTextPlain()
+        LensWithTextPlain() ∘ (@lens _.b)
+        (@lens _.a) ∘ LensWithTextPlain() ∘ (@lens _.b)
+    ]
+        @test occursin("I define text/plain.", sprint(show, "text/plain", lens))
+    end
 end
 
 @testset "Named Tuples" begin


### PR DESCRIPTION
Context: I'm playing with pretty-printer for Kaleido.jl https://github.com/tkf/Kaleido.jl/pull/6 and noticed that there is no easy way to extend `show(io::IO, ::MIME"text/plain", l::Lens)`. For example, if I call `show(stdout, "text/plain", mylens ∘ (@lens _.a))`, Julia calls `show(::IO, ::MIME"text/plain", ::Any)` which calls `show(::IO, ::ComposedLens)`. So, by the time my `show` method is called, the mime type is gone.

I think the easiest would be to pass around the mime type in Setfield.jl.