### PR TITLE
Fix text/plain show to avoid StackOverflowError

### DIFF
--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -8,4 +8,12 @@ include("sugar.jl")
 include("functionlenses.jl")
 include("settable.jl")
 include("experimental.jl")
+
+for n in names(Setfield, all=true)
+    T = getproperty(Setfield, n)
+    if T isa Type && T <: Lens && (T === ComposedLens || has_atlens_support(T))
+        @eval Base.show(io::IO, l::$T) = _show(io, nothing, l)
+    end
+end
+
 end

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -9,6 +9,13 @@ include("functionlenses.jl")
 include("settable.jl")
 include("experimental.jl")
 
+# To correctly dispatch to `show(::IO, ::CustomLens)` when it is defined by a
+# user, we avoid defining the generic `show(::IO, ::Lens)`.  This way, we can
+# safely call `show` inside `ComposedLens` without worrying about the
+# `StackOverflowError` that can be easily triggered in the previous approach.
+# See also:
+# * https://github.com/jw3126/Setfield.jl/pull/86
+# * https://github.com/jw3126/Setfield.jl/pull/88
 for n in names(Setfield, all=true)
     T = getproperty(Setfield, n)
     if T isa Type && T <: Lens && (T === ComposedLens || has_atlens_support(T))

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -207,13 +207,13 @@ Base.show(io::IO, ::MIME"text/plain", l::Lens) = _show(io, MIME("text/plain"), l
 function _show(io::IO, mime, l::Lens)
     if has_atlens_support(l)
         print_in_atlens(io, l)
-    elseif mime === nothing
+    elseif mime === nothing || get(io, :__Setfield_recursing, false)
         show_generic(io, l)
     else
         # Downstream packages may define specific show for text/plain.
         # Dispatch to their method rather than our `show_generic` in this
         # case.
-        show(io, mime, l)
+        show(IOContext(io, :__Setfield_recursing => true), mime, l)
     end
 end
 

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -166,11 +166,12 @@ macro lens(ex)
     lens
 end
 
-has_atlens_support(::Any) = false
-has_atlens_support(::Union{PropertyLens, IndexLens, ConstIndexLens, FunctionLens, IdentityLens}) =
+has_atlens_support(l::Lens) = has_atlens_support(typeof(l))
+has_atlens_support(::Type{<:Lens}) = false
+has_atlens_support(::Type{<:Union{PropertyLens, IndexLens, ConstIndexLens, FunctionLens, IdentityLens}}) =
     true
-has_atlens_support(l::ComposedLens) =
-    has_atlens_support(l.outer) && has_atlens_support(l.inner)
+has_atlens_support(::Type{ComposedLens{LO, LI}}) where {LO, LI} =
+    has_atlens_support(LO) && has_atlens_support(LI)
 
 print_application(io::IO, l::PropertyLens{field}) where {field} = print(io, ".", field)
 print_application(io::IO, l::IndexLens) = print(io, "[", join(repr.(l.indices), ", "), "]")
@@ -201,8 +202,8 @@ function print_application(printer, io, l::ComposedLens)
     end
 end
 
-Base.show(io::IO, l::Lens) = _show(io, nothing, l)
-Base.show(io::IO, ::MIME"text/plain", l::Lens) = _show(io, MIME("text/plain"), l)
+Base.show(io::IO, ::MIME"text/plain", l::ComposedLens) =
+    _show(io, MIME("text/plain"), l)
 
 function _show(io::IO, mime, l::Lens)
     if has_atlens_support(l)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -202,6 +202,10 @@ function print_application(printer, io, l::ComposedLens)
     end
 end
 
+# Since `show` of `ComposedLens` needs to call `show` of other lenses,
+# we explicitly define text/plain `show` for `ComposedLens` to propagate
+# the "context" (2-arg or 3-arg `show`) with which `show` has to be called.
+# See: https://github.com/jw3126/Setfield.jl/pull/86
 Base.show(io::IO, ::MIME"text/plain", l::ComposedLens) =
     _show(io, MIME("text/plain"), l)
 

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -209,11 +209,8 @@ function _show(io::IO, mime, l::Lens)
     if has_atlens_support(l)
         print_in_atlens(io, l)
     elseif mime === nothing
-        show_generic(io, l)
+        show(io, l)
     else
-        # Downstream packages may define specific show for text/plain.
-        # Dispatch to their method rather than our `show_generic` in this
-        # case.
         show(io, mime, l)
     end
 end
@@ -235,10 +232,3 @@ function print_in_atlens(io, l)
     end
     print(io, ')')
 end
-
-function show_generic(io::IO, args...)
-    types = tuple(typeof(io), Base.Iterators.repeated(Any, length(args))...)
-    Types = Tuple{types...}
-    invoke(show, Types, io, args...)
-end
-show_generic(args...) = show_generic(stdout, args...)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -207,13 +207,13 @@ Base.show(io::IO, ::MIME"text/plain", l::Lens) = _show(io, MIME("text/plain"), l
 function _show(io::IO, mime, l::Lens)
     if has_atlens_support(l)
         print_in_atlens(io, l)
-    elseif mime === nothing || get(io, :__Setfield_recursing, false)
+    elseif mime === nothing
         show_generic(io, l)
     else
         # Downstream packages may define specific show for text/plain.
         # Dispatch to their method rather than our `show_generic` in this
         # case.
-        show(IOContext(io, :__Setfield_recursing => true), mime, l)
+        show(io, mime, l)
     end
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -372,6 +372,15 @@ end
     ]
         @test occursin("I define text/plain.", sprint(show, "text/plain", lens))
     end
+
+    @testset for lens in [
+        UserDefinedLens()
+        (@lens _.a) ∘ UserDefinedLens()
+        UserDefinedLens() ∘ (@lens _.b)
+        (@lens _.a) ∘ UserDefinedLens() ∘ (@lens _.b)
+    ]
+        @test sprint(show, lens) == sprint(show, "text/plain", lens)
+    end
 end
 
 @testset "Named Tuples" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -356,13 +356,6 @@ Setfield.constructor_of(::Type{<: B{T}}) where T = B{T}
     @test obj2 === B{1}(2, :three)
 end
 
-@testset "show_generic" begin
-    l = @lens _[1]
-    s = sprint(Setfield.show_generic,l)
-    l2 = eval(Meta.parse(s))
-    @test l == l2
-end
-
 @testset "text/plain show" begin
     @testset for lens in [
         LensWithTextPlain()


### PR DESCRIPTION
PR #86 introduced a horrible bug that causes `StackOverflowError` when a user-defined function does not define text/plain `show`.  This PR fixes it by manually detecting recursion.  It's rather ugly so I'm open to other solutions (e.g., rename `_show` to `showlens` and expose it as a public API).
