### PR TITLE
better printing for lens types

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -303,3 +303,21 @@ function print_in_atlens(io, l)
     end
     print(io, ')')
 end
+
+_instance(T::Type{<:Union{PropertyLens,ConstIndexLens,FunctionLens}}) = T()
+function _instance(T::Type{ComposedLens{U,V}}) where {U,V}
+    instances = _instance.((U, V))
+    any(==(nothing), instances) && return nothing
+    return T(instances...)
+end
+_instance(::Any) = nothing
+
+function Base.show(io::IO, T::Type{<:Lens})
+    instance = _instance(T)
+    if instance !== nothing
+        print(io, "typeof")
+        show(io, instance)
+    else
+        invoke(Base.show, Tuple{IO,Type}, io, T)
+    end
+end

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -318,6 +318,6 @@ function Base.show(io::IO, T::Type{<:Lens})
         print(io, "typeof")
         show(io, instance)
     else
-        invoke(Base.show, Tuple{IO,Type}, io, T)
+        invoke(Base.show, Tuple{IO,DataType}, io, T)
     end
 end

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -313,6 +313,7 @@ end
 _instance(::Any) = nothing
 
 function Base.show(io::IO, T::Type{<:Lens})
+    T isa UnionAll && return invoke(Base.show, Tuple{IO,UnionAll}, io, T)
     instance = _instance(T)
     if instance !== nothing
         print(io, "typeof")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -158,6 +158,11 @@ Base.show(io::IO, ::MIME"text/plain", ::LensWithTextPlain) =
         show(buf, item)
         item2 = eval(Meta.parse(String(take!(buf))))
         @test item === item2
+
+        # showing of Type{<:Lens}
+        show(buf, typeof(item))
+        typeof_item2 = eval(Meta.parse(String(take!(buf))))
+        @test typeof(item) === typeof_item2
     end
 end
 

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -166,6 +166,24 @@ Base.show(io::IO, ::MIME"text/plain", ::LensWithTextPlain) =
     end
 end
 
+@testset "show of UnionAll <: Lens" begin
+    for s in [
+        "Lens",
+        "IdentityLens",
+        "PropertyLens",
+        "ComposedLens",
+        "IndexLens",
+        "ConstIndexLens",
+        "DynamicIndexLens",
+        "FunctionLens",
+    ]
+        s = "Setfield.$s"
+        buf = IOBuffer()
+        show(buf, eval(Meta.parse(s)))
+        @test s == String(take!(buf))
+    end
+end
+
 function test_getset_laws(lens, obj, val1, val2)
 
     # set ∘ get


### PR DESCRIPTION
Addresses #85. Also uses this better printing for types `PropertyLens`, `ConstIndexLens` and `ComposedLens`.