### PR TITLE
Upper-bound dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,8 @@ ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-MacroTools = "≥ 0.4.4"
+ConstructionBase = "0.1"
+MacroTools = "0.4.4, 0.5"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I think now it's better to upper bound so that registration would be automated.

FYI it looks like we can use https://github.com/bcbi/CompatHelper.jl to auto-bump compat via GitHub action.