### PR TITLE
Allow changing type via Setfield.setindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.2"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ConstructionBase = "0.1, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.5.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -2,6 +2,7 @@ __precompile__(true)
 module Setfield
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
+using Requires: @require
 
 if VERSION < v"1.1-"
     using Future: copy!
@@ -25,6 +26,13 @@ for n in names(Setfield, all=true)
     T = getproperty(Setfield, n)
     if T isa Type && T <: Lens && (T === ComposedLens || has_atlens_support(T))
         @eval Base.show(io::IO, l::$T) = _show(io, nothing, l)
+    end
+end
+
+function __init__()
+    @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin
+        setindex(a::StaticArrays.StaticArray, args...) =
+            Base.setindex(a, args...)
     end
 end
 

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -3,6 +3,10 @@ module Setfield
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
 
+if VERSION < v"1.1-"
+    using Future: copy!
+end
+
 include("setindex.jl")
 include("lens.jl")
 include("sugar.jl")

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -2,12 +2,21 @@ Base.@propagate_inbounds function setindex(args...)
     Base.setindex(args...)
 end
 
-for T in [:Array, :Dict]
-    @eval begin
-        Base.@propagate_inbounds function setindex(o::$T, args...)
-            new = copy(o)
-            setindex!(new, args...)
-            new
-        end
+Base.@propagate_inbounds function setindex(xs::AbstractArray, v, I...)
+    T = promote_type(eltype(xs), typeof(v))
+    ys = similar(xs, T)
+    if eltype(xs) !== Union{}
+        copy!(ys, xs)
     end
+    ys[I...] = v
+    return ys
+end
+
+Base.@propagate_inbounds function setindex(d0::AbstractDict, v, k)
+    K = promote_type(keytype(d0), typeof(k))
+    V = promote_type(valtype(d0), typeof(v))
+    d = empty(d0, K, V)
+    copy!(d, d0)
+    d[k] = v
+    return d
 end

--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -2,6 +2,19 @@ module TestSetindex
 using Setfield
 using Test
 
+"""
+    ==ₜ(x, y)
+
+Check that _type_ and value of `x` and `y` are equal.
+"""
+==ₜ(_, _) = false
+==ₜ(x::T, y::T) where T = x == y
+
+@testset "==ₜ" begin
+    @test 1 ==ₜ 1
+    @test !(1.0 ==ₜ 1)
+end
+
 @testset "setindex" begin
     arr = [1,2,3]
     @test_throws MethodError Base.setindex(arr, 10, 1)
@@ -9,6 +22,7 @@ using Test
     @test arr == [1,2,3]
     @test @set(arr[1] = 10) == [10, 2, 3]
     @test arr == [1,2,3]
+    @test Setfield.setindex(arr, 10.0, 1) ==ₜ Float64[10.0, 2.0, 3.0]
 
     d = Dict(:a => 1, :b => 2)
     @test_throws MethodError Base.setindex(d, 10, :a)
@@ -16,6 +30,8 @@ using Test
     @test d == Dict(:a => 1, :b => 2)
     @test @set(d[:a] = 10) == Dict(:a=>10, :b=>2)
     @test d == Dict(:a => 1, :b => 2)
+    @test Setfield.setindex(d, 30, "c") ==ₜ Dict(:a=>1, :b=>2, "c"=>30)
+    @test Setfield.setindex(d, 10.0, :a) ==ₜ Dict(:a=>10.0, :b=>2.0)
 end
 
 end


### PR DESCRIPTION
This is a PR against #107 to add BangBang-like type-widening semantics to `Setfield.setindex`.