### PR TITLE
Remove show(::IO, ::Type{<:FunctionLens{S}}) (revert #99)

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -307,8 +307,3 @@ function print_in_atlens(io, l)
     end
     print(io, ')')
 end
-
-function Base.show(io::IO, T::Type{<:FunctionLens{S}}) where S
-   print(io, "typeof")
-   show(io, T())
-end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -170,7 +170,7 @@ end
     buf = IOBuffer()
     flens = @lens first(_)
     show(buf, typeof(flens))
-    @test String(take!(buf)) == "typeof(@lens first(_))"
+    @test String(take!(buf)) == "typeof$flens"
 
     # test correct printing of UnionAll
     show(buf, Setfield.FunctionLens)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -158,23 +158,7 @@ Base.show(io::IO, ::MIME"text/plain", ::LensWithTextPlain) =
         show(buf, item)
         item2 = eval(Meta.parse(String(take!(buf))))
         @test item === item2
-
-        # showing of Type{<:Lens}
-        show(buf, typeof(item))
-        typeof_item2 = eval(Meta.parse(String(take!(buf))))
-        @test typeof(item) === typeof_item2
     end
-end
-
-@testset "show of typeof(::FunctionLens)" begin
-    buf = IOBuffer()
-    flens = @lens first(_)
-    show(buf, typeof(flens))
-    @test String(take!(buf)) == "typeof$flens"
-
-    # test correct printing of UnionAll
-    show(buf, Setfield.FunctionLens)
-    @test String(take!(buf)) == "Setfield.FunctionLens"
 end
 
 function test_getset_laws(lens, obj, val1, val2)


### PR DESCRIPTION
It turned out this method causes segfaults in VS Code extension. I think we better play on the safe side.

close #113