### PR TITLE
deprecate MultiPropertyLens and @settable

### DIFF
--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -7,6 +7,12 @@ export MultiPropertyLens
 const NNamedTupleLens{N,s} = NamedTuple{s, T} where {T <: NTuple{N, Lens}}
 struct MultiPropertyLens{L <: NNamedTupleLens} <: Lens
     lenses::L
+    function MultiPropertyLens(lenses::L) where {L <: NNamedTupleLens}
+        @warn """
+        `MultiPropertyLens` is planned to be removed. Please see [`Kaleido.jl`](https://github.com/tkf/Kaleido.jl) for a couple of similar useful lenses.
+        """
+        new{L}(lenses)
+    end
 end
 
 _keys(::Type{MultiPropertyLens{NamedTuple{s,T}}}) where {s,T} = s

--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -8,9 +8,10 @@ const NNamedTupleLens{N,s} = NamedTuple{s, T} where {T <: NTuple{N, Lens}}
 struct MultiPropertyLens{L <: NNamedTupleLens} <: Lens
     lenses::L
     function MultiPropertyLens(lenses::L) where {L <: NNamedTupleLens}
-        @warn """
+        msg = """
         `MultiPropertyLens` is planned to be removed. Please see [`Kaleido.jl`](https://github.com/tkf/Kaleido.jl) for a couple of similar useful lenses.
         """
+        Base.depwarn(msg, :MultiPropertyLens)
         new{L}(lenses)
     end
 end

--- a/src/settable.jl
+++ b/src/settable.jl
@@ -4,13 +4,14 @@ using MacroTools: splitdef, combinedef
 using MacroTools: splitstructdef, isstructdef, combinestructdef
 
 macro settable(ex)
-    @warn """
+    msg = """
     `Setfield.@settable` is planned to be removed. We believe that it is no longer needed.
     Please try to remove it from your code. This might involve fixing some constructor calls,
     but should be easy. If it turns out hard and you believe you have a use case, where `@settable`
     is really crucial, please open an issue in the `Setfield` github repo:
     https://github.com/jw3126/Setfield.jl/issues
     """
+    Base.depwarn(msg, Symbol("@settable"))
     esc(settable(__module__, ex))
 end
 

--- a/src/settable.jl
+++ b/src/settable.jl
@@ -4,6 +4,13 @@ using MacroTools: splitdef, combinedef
 using MacroTools: splitstructdef, isstructdef, combinestructdef
 
 macro settable(ex)
+    @warn """
+    `Setfield.@settable` is planned to be removed. We believe that it is no longer needed.
+    Please try to remove it from your code. This might involve fixing some constructor calls,
+    but should be easy. If it turns out hard and you believe you have a use case, where `@settable`
+    is really crucial, please open an issue in the `Setfield` github repo:
+    https://github.com/jw3126/Setfield.jl/issues
+    """
     esc(settable(__module__, ex))
 end
 


### PR DESCRIPTION
I think `@settable` is an evil no longer necessary and `MulitPropertyLens` was never really the "right design" anyway.