### PR TITLE
Fix the link to dev version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/jw3126/Setfield.jl.svg?branch=master)](https://travis-ci.org/jw3126/Setfield.jl)
 [![codecov.io](https://codecov.io/github/jw3126/Setfield.jl/coverage.svg?branch=master)](http://codecov.io/github/jw3126/Setfield.jl?branch=master)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://jw3126.github.io/Setfield.jl/stable/intro)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://jw3126.github.io/Setfield.jl/latest/intro)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://jw3126.github.io/Setfield.jl/dev/intro)
 
 Update deeply nested immutable structs.
 


### PR DESCRIPTION
<strike>ATM it's linking to old dev version https://jw3126.github.io/Setfield.jl/latest/intro</strike>