### PR TITLE
Fix Travis setup to build documentation (merge jobs and matrix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,12 @@ notifications:
 git:
   depth: 99999999
 
-matrix:
+jobs:
   allow_failures:
   - julia: nightly
   include:
       - os: osx
         julia: 1.0
-
-jobs:
-  include:
     - stage: "Documentation"
       julia: 1.4
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ jobs:
   allow_failures:
   - julia: nightly
   include:
-      - os: osx
-        julia: 1.0
+    - os: osx
+      julia: 1.0
     - stage: "Documentation"
       julia: 1.4
       os: linux


### PR DESCRIPTION
I realized that documentation buidl is not run in Travis anymore. e.g., https://travis-ci.org/github/jw3126/Setfield.jl/builds/687356039

This is because Traivs stopped automatically merging `jobs` and `matrix` config sometime ago.
