### PR TITLE
Move internal docstrings to a hidden page

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(
             "Introduction" => "intro.md",
             "Docstrings" => "index.md",
             "Custom Macros" => "examples/custom_macros.md",
+             hide("internals.md"),
             ],
         strict = true,  # to exit with non-zero code on error
         )

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,6 +1,6 @@
-## Docstrings
+# Internals
 
 ```@autodocs
 Modules = [Setfield]
-Private = false
+Public = false
 ```


### PR DESCRIPTION
Currently, all functions with docstring is included in the documentation.  I think it's better to move private ones to a hidden page.