### PR TITLE
`@set` and `@set!` to change multiple fields

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -43,8 +43,15 @@ SpaceShip(Person(:JULIA, 2009), [999999.0, 0.0, 0.0], [0.0, 0.0, 0.0])
 julia> s = @set s.velocity[1] += 1000001
 SpaceShip(Person(:JULIA, 2009), [2.0e6, 0.0, 0.0], [0.0, 0.0, 0.0])
 
-julia> @set s.position[2] = 20
+julia> s = @set s.position[2] = 20
 SpaceShip(Person(:JULIA, 2009), [2.0e6, 0.0, 0.0], [0.0, 20.0, 0.0])
+```
+
+Setting multiple fields also works
+
+```jldoctest spaceship
+julia> @set s.captain.name = :Julia s.captain.age = 1 s.position[1] = 3
+SpaceShip(Person(:Julia, 1), [2.0e6, 0.0, 0.0], [3.0, 20.0, 0.0])
 ```
 
 ## Under the hood

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -180,7 +180,7 @@ function setmacro(lenstransform, exprs::Expr...; overwrite::Bool=false)
         val = (ex.args)[2]
         lens = lenses[idx]
         val = esc(val)
-        if idx >1
+        if idx == 2 && !overwrite
             obj = dst
         end
         ret.args[idx] = if ex.head == :(=)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -37,8 +37,8 @@ end
 
     @set! t.b.a = 20
     @test t === T(1,T(20,3))
-    @set! t.a = 10 t.b.a = 30
-    @test t === T(10,T(30,3))
+    @set! t.a = 10 t.b.a = 30 t.b.b = 0
+    @test t === T(10,T(30,0))
 
     a = 1
     @set! a += 10
@@ -52,10 +52,10 @@ end
 
     t = T(1, T(2, T(T(4,4),3)))
     s = @set t.b.b.a.a = 5
-    s2 = @set t.a = 10 t.b.a = 3
+    s2 = @set t.a = 10 t.b.a = 20 t.b.b.a.b = 9
     @test t === T(1, T(2, T(T(4,4),3)))
     @test s === T(1, T(2, T(T(5, 4), 3)))
-    @test s2 === T(10, T(3, T(T(4,4),3)))
+    @test s2 === T(10, T(20, T(T(4, 9),3)))
     @test_throws ArgumentError @set t.b.b.a.a.a = 3
 
     t = T(1,2)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -37,6 +37,8 @@ end
 
     @set! t.b.a = 20
     @test t === T(1,T(20,3))
+    @set! t.a = 10 t.b.a = 30
+    @test t === T(10,T(30,3))
 
     a = 1
     @set! a += 10
@@ -50,8 +52,10 @@ end
 
     t = T(1, T(2, T(T(4,4),3)))
     s = @set t.b.b.a.a = 5
+    s2 = @set t.a = 10 t.b.a = 3
     @test t === T(1, T(2, T(T(4,4),3)))
     @test s === T(1, T(2, T(T(5, 4), 3)))
+    @test s2 === T(10, T(3, T(T(4,4),3)))
     @test_throws ArgumentError @set t.b.b.a.a.a = 3
 
     t = T(1,2)


### PR DESCRIPTION
A simple implementation for `@set` and `@set!` to change multiple fields, eg https://github.com/jw3126/Setfield.jl/issues/62.

`@set expr_1 expr_2 ... expr_n`

Some details:

- moved `@assert ex.head isa Symbol` and `@assert length(ex.args) == 2` to a function `set_asserts()` and check via `@assert all(set_asserts.(exprs))`
- get `obj` and `lens` for all expressions via a function `get_obj_lens(exprs)`: checks all expressions are on the same object (such that `@set d.a=1 x.y=2` would fail since it acts on two objects d and x); returns the one object to act on and all lenses
- for the non-overwriting `@set`, from the 2nd expression `expr_2` on, the object would become the destination gensym `dst` otherwise only the last change would apply (only need to be set once). Essentially, set the gensym `dst` with expr_1 and use the new dst as obj for expr_2 through expr_n
- also added test to change multiple fields
- since `@assert` [might be disabled at various optimization levels](https://docs.julialang.org/en/v1/base/base/#Base.@assert), shall we change to use if or is it good as-is?

I originally wanted to keep the original `setmacro` function and call it through all expressions in a new wrapper but since in the non-overwriting mode, dst would be set to a new gensym variable each time `setmacro` gets called, I implemented it inside `setmacro` here.

ex.
```
struct foo
    a
    b
    c
end

d = foo(1,2,3)
```

`q = @set d.a = 10 d.b = 20 d.c = 30`
> foo(10, 20, 30)

`q = @set d.a += 10 d.b *= 20 d.c -= 30`
> foo(11, 40, -27)

`@set! d.a = 11 d.b = -1`
> foo(11, -1, 3)