### PR TITLE
Rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ git:
   depth: 99999999
 
 jobs:
-  allow_failures:
-  - julia: nightly
   include:
     - os: osx
-      julia: 1.0
+      julia: nightly
     - stage: "Documentation"
-      julia: 1.4
+      julia: nightly
       os: linux
       script: julia --project=docs --color=yes -e '
           using Pkg;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: julia
 os:
   - linux
 julia:
-  - 1.0
-  - 1.4
-  - 1.5
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,12 @@ uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 version = "0.7.0"
 
 [deps]
+CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticNumbers = "c5e4b96a-f99f-5557-8ed2-dc63ef9b5131"
 
 [compat]
 ConstructionBase = "0.1, 1.0"
@@ -26,4 +28,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Documenter", "PerformanceTestTools", "QuickTypes", "StaticArrays", "BenchmarkTools", "InteractiveUtils", "StaticNumbers"]
-

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
@@ -14,7 +14,7 @@ StaticNumbers = "c5e4b96a-f99f-5557-8ed2-dc63ef9b5131"
 ConstructionBase = "0.1, 1.0"
 MacroTools = "0.4.4, 0.5"
 Requires = "0.5, 1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
          sitename = "Setfield.jl",
          pages = [
             "Introduction" => "intro.md",
+            "Lenses" => "lenses.md",
             "Docstrings" => "index.md",
             "Custom Macros" => "examples/custom_macros.md",
              hide("internals.md"),

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -56,7 +56,7 @@ This api may be useful in its own right and works as follows:
 julia> using Setfield
 
 julia> l = @lens _.a.b
-(@lens _.a.b)
+(@lens _.b) ∘ (@lens _.a)
 
 julia> struct AB;a;b;end
 
@@ -69,7 +69,7 @@ AB(AB(1, 42), 3)
 julia> obj
 AB(AB(1, 2), 3)
 
-julia> get(obj, l)
+julia> l(obj)
 2
 
 julia> modify(x->10x, obj, l)

--- a/docs/src/lenses.md
+++ b/docs/src/lenses.md
@@ -1,0 +1,54 @@
+# Lenses
+
+Setfield.jl is build around so called lenses. A Lens allows to access or replace deeply nested parts of complicated objects.
+
+# Example
+```jldoctest
+julia> using Setfield
+
+julia> struct T;a;b; end
+
+julia> obj = T("AA", "BB");
+
+julia> lens = @lens _.a
+(@lens _.a)
+
+julia> lens(obj)
+"AA"
+
+julia> set(obj, lens, 2)
+T(2, "BB")
+
+julia> obj # the object was not mutated, instead an updated copy was created
+T("AA", "BB")
+
+julia> modify(lowercase, obj, lens)
+T("aa", "BB")
+```
+
+# Interface
+
+Implementing lenses is straight forward. They can be of any type and just need to implement the following interface:
+* `Setfield.set(obj, lens, val)`
+* `lens(obj)`
+
+These must be pure functions, that satisfy the three lens laws:
+
+```jldoctest; output = false, setup = :(using Setfield; (≅ = (==)); obj = (a="A", b="B"); lens = @lens _.a; val = 2; val1 = 10; val2 = 20)
+@assert lens(set(obj, lens, val)) ≅ val
+        # You get what you set.
+@assert set(obj, lens, lens(obj)) ≅ obj
+        # Setting what was already there changes nothing.
+@assert set(set(obj, lens, val1), lens, val2) ≅ set(obj, lens, val2)
+        # The last set wins.
+
+# output
+
+```
+Here `≅` is an appropriate notion of equality or an approximation of it. In most contexts
+this is simply `==`. But in some contexts it might be `===`, `≈`, `isequal` or something
+else instead. For instance `==` does not work in `Float64` context, because
+`get(set(obj, lens, NaN), lens) == NaN` can never hold. Instead `isequal` or
+`≅(x::Float64, y::Float64) = isequal(x,y) | x ≈ y` are possible alternatives.
+
+See also [`@lens`](@ref), [`set`](@ref), [`modify`](@ref).

--- a/examples/custom_macros.jl
+++ b/examples/custom_macros.jl
@@ -1,7 +1,7 @@
 # # Extending `@set` and `@lens`
 # This code demonstrates how to extend the `@set` and `@lens` mechanism with custom
 # lenses.
-# As a demo, we want to implement `@mylens!` and `@myset!`, which work much like 
+# As a demo, we want to implement `@mylens!` and `@myreset`, which work much like 
 # `@lens` and `@set`, but mutate objects instead of returning modified copies.
 
 using Setfield
@@ -49,7 +49,7 @@ set(o, l, 100)
 
 using Setfield: setmacro, lensmacro
 
-macro myset!(ex)
+macro myreset(ex)
     setmacro(Lens!, ex)
 end
 
@@ -58,13 +58,13 @@ macro mylens!(ex)
 end
 
 o = M(1,2)
-@myset! o.a = :hi
-@myset! o.b += 98
+@myreset o.a = :hi
+@myreset o.b += 98
 @test o.a == :hi
 @test o.b == 100
 
 deep = [[[[1]]]]
-@myset! deep[1][1][1][1] = 2
+@myreset deep[1][1][1][1] = 2
 @test deep[1][1][1][1] === 2
 
 l = @mylens! _.foo[1]

--- a/examples/custom_macros.jl
+++ b/examples/custom_macros.jl
@@ -12,15 +12,15 @@ struct Lens!{L}
 end
 
 (l::Lens!)(o) = l.pure(o)
-function Setfield.set(l::Lens!{<: ComposedLens}, o, val)
+function Setfield.set(o, l::Lens!{<: ComposedLens}, val)
     o_inner = Setfield.inner(l.pure)(o)
-    set(Lens!(Setfield.outer(l.pure)), o_inner, val)
+    set(o_inner, Lens!(Setfield.outer(l.pure)), val)
 end
-function Setfield.set(l::Lens!{PropertyLens{prop}}, o, val) where {prop}
+function Setfield.set(o, l::Lens!{PropertyLens{prop}}, val) where {prop}
     setproperty!(o, prop, val)
     o
 end
-function Setfield.set(l::Lens!{<:IndexLens}, o, val) where {prop}
+function Setfield.set(o, l::Lens!{<:IndexLens}, val) where {prop}
     o[l.pure.indices...] = val
     o
 end
@@ -37,12 +37,12 @@ end
 
 o = M(1,2)
 l = Lens!(@lens _.b)
-set(l, o, 20)
+set(o, l, 20)
 @test o.b == 20
 
 l = Lens!(@lens _.foo[1])
 o = (foo=[1,2,3], bar=:bar)
-set(l, o, 100)
+set(o, l, 100)
 @test o == (foo=[100,2,3], bar=:bar)
 
 # Now we can implement the syntax macros
@@ -69,7 +69,7 @@ deep = [[[[1]]]]
 
 l = @mylens! _.foo[1]
 o = (foo=[1,2,3], bar=:bar)
-set(l, o, 100)
+set(o, l, 100)
 @test o == (foo=[100,2,3], bar=:bar)
 
 # Everything works, we can do arbitrary nesting and also use `+=` syntax etc.

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -1,4 +1,3 @@
-__precompile__(true)
 module Setfield
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
@@ -7,11 +6,6 @@ using Requires: @require
 # TODO erase these
 const get = nothing
 const Lens = nothing
-
-
-if VERSION < v"1.1-"
-    using Future: copy!
-end
 
 include("setindex.jl")
 include("lens.jl")

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -6,6 +6,7 @@ using Requires: @require
 
 # TODO erase these
 const get = nothing
+const Lens = nothing
 
 
 if VERSION < v"1.1-"
@@ -16,20 +17,6 @@ include("setindex.jl")
 include("lens.jl")
 include("sugar.jl")
 include("functionlenses.jl")
-
-# To correctly dispatch to `show(::IO, ::CustomLens)` when it is defined by a
-# user, we avoid defining the generic `show(::IO, ::Lens)`.  This way, we can
-# safely call `show` inside `ComposedLens` without worrying about the
-# `StackOverflowError` that can be easily triggered in the previous approach.
-# See also:
-# * https://github.com/jw3126/Setfield.jl/pull/86
-# * https://github.com/jw3126/Setfield.jl/pull/88
-for n in names(Setfield, all=true)
-    T = getproperty(Setfield, n)
-    if T isa Type && T <: Lens && (T === ComposedLens || has_atlens_support(T))
-        @eval Base.show(io::IO, l::$T) = _show(io, nothing, l)
-    end
-end
 
 function __init__()
     @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -3,10 +3,6 @@ using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
 using Requires: @require
 
-# TODO erase these
-const get = nothing
-const Lens = nothing
-
 include("setindex.jl")
 include("lens.jl")
 include("sugar.jl")

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -4,6 +4,10 @@ using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
 using Requires: @require
 
+# TODO erase these
+const get = nothing
+
+
 if VERSION < v"1.1-"
     using Future: copy!
 end

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -18,3 +18,9 @@ set(obj::Type{<:Dict{<:Any,V}}, lens::typeof(keytype), ::Type{K}) where {K, V} =
     Dict{K, V}
 set(obj::Type{<:Dict{K}}, lens::typeof(valtype), ::Type{V}) where {K, V} =
     Dict{K, V}
+
+################################################################################
+##### os
+################################################################################
+set(path, ::typeof(splitext), (stem, ext)) = string(stem, ext)
+set(path, ::typeof(splitdir), (dir, last)) = joinpath(dir, last)

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -1,10 +1,11 @@
-set(obj, ::typeof(@lens last(_)), val) = @set obj[lastindex(obj)] = val
-set(obj, ::typeof(@lens first(_)), val) = @set obj[firstindex(obj)] = val
+set(::typeof(last), obj, val) = @set obj[lastindex(obj)] = val
+set(::typeof(first), obj, val) = @set obj[firstindex(obj)] = val
+set(::typeof(identity), obj, val) = val
 
 ################################################################################
 ##### eltype
 ################################################################################
-function set(obj, ::typeof(@lens eltype(_)), ::Type{T}) where {T}
+function set(::typeo(eltype), obj, ::Type{T}) where {T}
     return set_eltype(obj, T)
 end
 
@@ -15,9 +16,9 @@ set_eltype(::Type{<:Array{<:Any, N}}, ::Type{T}) where {N, T} = Array{T, N}
 set_eltype(::Type{<:Dict}, ::Type{Pair{K, V}}) where {K, V} = Dict{K, V}
 set_eltype(obj::Dict, ::Type{T}) where {T} = set_eltype(typeof(obj), T)(obj)
 
-set(obj::Dict, l::Union{typeof(@lens keytype(_)), typeof(@lens valtype(_))},
-    T::Type) = set(typeof(obj), l, T)(obj)
-set(::Type{<:Dict{<:Any,V}}, ::typeof(@lens keytype(_)), ::Type{K}) where {K, V} =
+set(lens::Union{typeof(keytype), typeof(valtype)}, obj::Dict, T::Type) =
+    set(lens, typeof(obj), T)(obj)
+set(lens::typeof(keytype), obj::Type{<:Dict{<:Any,V}}, ::Type{K}) where {K, V} =
     Dict{K, V}
-set(::Type{<:Dict{K}}, ::typeof(@lens valtype(_)), ::Type{V}) where {K, V} =
+set(lens::typeof(valtype), ::Type{<:Dict{K}}, ::Type{V}) where {K, V} =
     Dict{K, V}

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -1,24 +1,20 @@
-set(::typeof(last), obj, val) = @set obj[lastindex(obj)] = val
-set(::typeof(first), obj, val) = @set obj[firstindex(obj)] = val
-set(::typeof(identity), obj, val) = val
+set(obj, ::typeof(last), val) = @set obj[lastindex(obj)] = val
+set(obj, ::typeof(first), val) = @set obj[firstindex(obj)] = val
+set(obj, ::typeof(identity), val) = val
 
 ################################################################################
 ##### eltype
 ################################################################################
-function set(::typeof(eltype), obj, ::Type{T}) where {T}
-    return set_eltype(obj, T)
-end
+set(obj::Array, ::typeof(eltype), T::Type) = collect(T, obj)
+set(obj::Number, ::typeof(eltype), T::Type) = T(obj)
+set(obj::Type{<:Number}, ::typeof(eltype), ::Type{T}) where {T} = T
+set(obj::Type{<:Array{<:Any, N}}, ::typeof(eltype), ::Type{T}) where {N, T} = Array{T, N}
+set(obj::Type{<:Dict}, ::typeof(eltype), ::Type{Pair{K, V}}) where {K, V} = Dict{K, V}
+set(obj::Dict, ::typeof(eltype), ::Type{T}) where {T} = set(typeof(obj), eltype, T)(obj)
 
-set_eltype(obj::Array,  T::Type) = collect(T, obj)
-set_eltype(obj::Number, T::Type) = T(obj)
-set_eltype(::Type{<:Number}, ::Type{T}) where {T} = T
-set_eltype(::Type{<:Array{<:Any, N}}, ::Type{T}) where {N, T} = Array{T, N}
-set_eltype(::Type{<:Dict}, ::Type{Pair{K, V}}) where {K, V} = Dict{K, V}
-set_eltype(obj::Dict, ::Type{T}) where {T} = set_eltype(typeof(obj), T)(obj)
-
-set(lens::Union{typeof(keytype), typeof(valtype)}, obj::Dict, T::Type) =
-    set(lens, typeof(obj), T)(obj)
-set(lens::typeof(keytype), obj::Type{<:Dict{<:Any,V}}, ::Type{K}) where {K, V} =
+set(obj::Dict, lens::Union{typeof(keytype), typeof(valtype)}, T::Type) =
+    set(typeof(obj), lens, T)(obj)
+set(obj::Type{<:Dict{<:Any,V}}, lens::typeof(keytype), ::Type{K}) where {K, V} =
     Dict{K, V}
-set(lens::typeof(valtype), ::Type{<:Dict{K}}, ::Type{V}) where {K, V} =
+set(obj::Type{<:Dict{K}}, lens::typeof(valtype), ::Type{V}) where {K, V} =
     Dict{K, V}

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -5,7 +5,7 @@ set(::typeof(identity), obj, val) = val
 ################################################################################
 ##### eltype
 ################################################################################
-function set(::typeo(eltype), obj, ::Type{T}) where {T}
+function set(::typeof(eltype), obj, ::Type{T}) where {T}
     return set_eltype(obj, T)
 end
 

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -84,7 +84,7 @@ const ComposedLens{Outer, Inner} = Base.ComposedFunction{Outer, Inner}
 outer(o::ComposedLens) = o.f
 inner(o::ComposedLens) = o.g
 
-@inline function set(obj, lens::Base.ComposedFunction, val)
+@inline function set(obj, lens::ComposedLens, val)
     inner_obj = inner(lens)(obj)
     inner_val = set(inner_obj, outer(lens), val)
     set(obj, inner(lens), inner_val)

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -68,14 +68,14 @@ See also [`@lens`](@ref), [`set`](@ref), [`get`](@ref), [`modify`](@ref).
 """
     modify(f, lens, obj)
 
-Replace a deeply nested part `x` of `obj` by `f(x)`. See also [`Lens`](@ref).
+Replace a deeply nested part `x` of `obj` by `f(x)`.
 """
 function modify end
 
 """
     set(lens, obj, val)
 
-Replace a deeply nested part of `obj` by `val`. See also [`Lens`](@ref).
+Replace a deeply nested part of `obj` by `val`.
 """
 function set end
 
@@ -94,18 +94,8 @@ end
     setproperties(obj, patch)
 end
 
-TODO = """
-    compose([lens₁, [lens₂, [lens₃, ...]]])
 
-Compose `lens₁`, `lens₂` etc. There is one subtle point here:
-While the two composition orders `(lens₁ ⨟ lens₂) ⨟ lens₃` and `lens₁ ⨟ (lens₂ ⨟ lens₃)` have equivalent semantics,
-their performance may not be the same. The compiler tends to optimize right associative composition
-(second case) better then left associative composition.
-
-The compose function tries to use a composition order, that the compiler likes. The composition order is therefore not part of the stable API.
 """
-
-TODO = """
     lens₁ ⨟ lens₂
 
 Compose lenses `lens₁`, `lens₂`, ..., `lensₙ` to access nested objects.

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -57,8 +57,6 @@ macro reset(ex)
     setmacro(identity, ex, overwrite=true)
 end
 
-is_interpolation(x) = x isa Expr && x.head == :$
-
 foldtree(op, init, x) = op(init, x)
 foldtree(op, init, ex::Expr) =
     op(foldl((acc, x) -> foldtree(op, acc, x), ex.args; init=init), ex)
@@ -105,8 +103,6 @@ function parse_obj_lenses(ex)
     elseif @capture(ex, (front_ |> funlens_))
         obj, frontlens = parse_obj_lenses(front)
         lens = esc(funlens)
-    elseif is_interpolation(ex)
-        error(string(ex))
     elseif @capture(ex, front_[indices__])
         obj, frontlens = parse_obj_lenses(front)
         if any(need_dynamic_lens, indices)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -81,26 +81,8 @@ function lower_index(collection::Symbol, index, dim)
     return index
 end
 
-function parse_obj_lenses_composite(lensexprs::Vector)
-    if isempty(lensexprs)
-        return esc(:_), ()
-    else
-        obj, outermostlens = parse_obj_lens(lensexprs[1])
-        innerlenses = map(lensexprs[2:end]) do innerex
-            o, lens = parse_obj_lens(innerex)
-            @assert o == esc(:_)
-            lens
-        end
-        return obj, (outermostlens, innerlenses...)
-    end
-end
-
 function parse_obj_lenses(ex)
-    if @capture(ex, ⨟(lensexprs__))
-        return parse_obj_lenses_composite(lensexprs)
-    elseif @capture(ex, ∘(lensexprs__))
-        return parse_obj_lenses_composite(reverse(lensexprs))
-    elseif @capture(ex, (front_ |> back_))
+    if @capture(ex, (front_ |> back_))
         obj, frontlens = parse_obj_lenses(front)
         backlens = try
             # allow e.g. obj |> first |> _.a.b

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -258,9 +258,8 @@ function lensmacro(lenstransform, ex)
     :($(lenstransform)($lens))
 end
 
-function Base.show(io::IO, lens::PropertyLens{field}) where {field}
-    print(io, "(@lens _.$field)")
-end
-function Base.show(io::IO, lens::IndexLens)
-    print(io, "(@lens _[", join(repr.(lens.indices), ", "), "])")
-end
+
+_show(io::IO, lens::PropertyLens{field}) where {field} = print(io, "(@lens _.$field)")
+_show(io::IO, lens::IndexLens) = print(io, "(@lens _[", join(repr.(lens.indices), ", "), "])")
+Base.show(io::IO, lens::Union{IndexLens, PropertyLens}) = _show(io, lens)
+Base.show(io::IO, ::MIME"text/plain", lens::Union{IndexLens, PropertyLens}) = _show(io, lens)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -27,6 +27,7 @@ T(T(2, 2), 2)
 julia> @set t.a.b = 3
 T(T(2, 3), 2)
 ```
+Supports the same syntax as [`@lens`](@ref). See also [`@reset`](@ref).
 """
 macro set(ex)
     setmacro(identity, ex, overwrite=false)
@@ -50,6 +51,7 @@ julia> @reset t.a=2
 julia> t
 (a = 2,)
 ```
+Supports the same syntax as [`@lens`](@ref). See also [`@set`](@ref).
 """
 macro reset(ex)
     setmacro(identity, ex, overwrite=true)
@@ -100,6 +102,9 @@ function parse_obj_lenses(ex)
         return parse_obj_lenses_composite(lensexprs)
     elseif @capture(ex, ∘(lensexprs__))
         return parse_obj_lenses_composite(reverse(lensexprs))
+    elseif @capture(ex, (front_ |> funlens_))
+        obj, frontlens = parse_obj_lenses(front)
+        lens = esc(funlens)
     elseif is_interpolation(ex)
         @assert length(ex.args) == 1
         return esc(:_), (esc(ex.args[1]),)
@@ -129,7 +134,7 @@ function parse_obj_lenses(ex)
         obj = esc(ex)
         return obj, ()
     end
-    obj, tuple(frontlens..., lens)
+    return obj, tuple(frontlens..., lens)
 end
 
 """
@@ -236,6 +241,7 @@ julia> set(t, (@lens _[1]), "1")
 ("1", "two")
 ```
 
+See also [`@set`](@ref).
 """
 macro lens(ex)
     lensmacro(identity, ex)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -106,8 +106,7 @@ function parse_obj_lenses(ex)
         obj, frontlens = parse_obj_lenses(front)
         lens = esc(funlens)
     elseif is_interpolation(ex)
-        @assert length(ex.args) == 1
-        return esc(:_), (esc(ex.args[1]),)
+        error(string(ex))
     elseif @capture(ex, front_[indices__])
         obj, frontlens = parse_obj_lenses(front)
         if any(need_dynamic_lens, indices)
@@ -275,3 +274,15 @@ _show(io::IO, lens::PropertyLens{field}) where {field} = print(io, "(@lens _.$fi
 _show(io::IO, lens::IndexLens) = print(io, "(@lens _[", join(repr.(lens.indices), ", "), "])")
 Base.show(io::IO, lens::Union{IndexLens, PropertyLens}) = _show(io, lens)
 Base.show(io::IO, ::MIME"text/plain", lens::Union{IndexLens, PropertyLens}) = _show(io, lens)
+
+# debugging
+show_composition_order(lens) = (show_composition_order(stdout, lens); println())
+show_composition_order(io::IO, lens) = show(io, lens)
+function show_composition_order(io::IO, lens::ComposedLens)
+    print(io, "(")
+    show_composition_order(io, outer(lens))
+    print(io, " ∘  ")
+    show_composition_order(io, inner(lens))
+    print(io, ")")
+end
+

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -184,14 +184,14 @@ function setmacro(lenstransform, ex::Expr; overwrite::Bool=false)
     ret = if ex.head == :(=)
         quote
             lens = ($lenstransform)($lens)
-            $dst = $set(lens, $obj, $val)
+            $dst = $set($obj, lens, $val)
         end
     else
         op = get_update_op(ex.head)
         f = :($_UpdateOp($op,$val))
         quote
             lens = ($lenstransform)($lens)
-            $dst = $modify($f, lens, $obj)
+            $dst = $modify($f, $obj, lens)
         end
     end
     ret

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -114,16 +114,16 @@ end
 
 function compose_left_assoc(obj, val)
     l = @lens ((_.a⨟_.b)⨟_.c)⨟_.d
-    set(obj, l, val)
+    set(l, obj, val)
 end
 
 function compose_right_assoc(obj, val)
     l = @lens _.a⨟(_.b⨟(_.c⨟_.d))
-    set(obj, l, val)
+    set(l, obj, val)
 end
 function compose_default_assoc(obj, val)
     l = @lens _.a.b.c.d
-    set(obj, l, val)
+    set(l, obj, val)
 end
 @testset "Lens composition compiler prefered associativity" begin
 

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -114,16 +114,16 @@ end
 
 function compose_left_assoc(obj, val)
     l = @lens ((_.a⨟_.b)⨟_.c)⨟_.d
-    set(l, obj, val)
+    set(obj, l, val)
 end
 
 function compose_right_assoc(obj, val)
     l = @lens _.a⨟(_.b⨟(_.c⨟_.d))
-    set(l, obj, val)
+    set(obj, l, val)
 end
 function compose_default_assoc(obj, val)
     l = @lens _.a.b.c.d
-    set(l, obj, val)
+    set(obj, l, val)
 end
 @testset "Lens composition compiler prefered associativity" begin
 

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -132,13 +132,14 @@ let
     end
 end
 
-function compose_left_assoc(obj, val)
-    l = @lens ((_.a⨟_.b)⨟_.c)⨟_.d
+function compose_right_assoc(obj, val)
+    l = @lens(_.d) ∘ (@lens(_.c) ∘ (@lens(_.b) ∘ @lens(_.a)))
     set(obj, l, val)
 end
 
-function compose_right_assoc(obj, val)
-    l = @lens _.a⨟(_.b⨟(_.c⨟_.d))
+function compose_left_assoc(obj, val)
+    l = ((@lens(_.d) ∘ @lens(_.c)) ∘ @lens(_.b)) ∘ @lens(_.a)
+    set(obj, l, val)
     set(obj, l, val)
 end
 function compose_default_assoc(obj, val)
@@ -161,11 +162,11 @@ end
     println("Right associative composition: $b_right")
 
     @test b_default.allocs == 0
-    @test b_right.allocs == 0
-    @test_broken b_left.allocs == 0
+    @test_broken b_right.allocs == 0
+    @test b_left.allocs == 0
 
-    @test b_left.time > 2b_default.time
-    @test b_right.time ≈ b_default.time rtol=0.8
+    @test b_right.time > 2b_default.time
+    @test b_left.time ≈ b_default.time rtol=0.8
 end
 
 end

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -113,12 +113,12 @@ let
 end
 
 function compose_left_assoc(obj, val)
-    l = @lens ((_.a∘_.b)∘_.c)∘_.d
+    l = @lens ((_.a⨟_.b)⨟_.c)⨟_.d
     set(obj, l, val)
 end
 
 function compose_right_assoc(obj, val)
-    l = @lens _.a∘(_.b∘(_.c∘_.d))
+    l = @lens _.a⨟(_.b⨟(_.c⨟_.d))
     set(obj, l, val)
 end
 function compose_default_assoc(obj, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,15 +4,16 @@ import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
-include("test_core.jl")
-include("test_functionlenses.jl")
+PerformanceTestTools.@include("perf.jl")
+include("test_examples.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")
 include("test_setmacro.jl")
 include("test_setindex.jl")
-include("test_examples.jl")
-PerformanceTestTools.@include("perf.jl")
+include("test_core.jl")
+include("test_functionlenses.jl")
 
-doctest(Setfield)
+
+# TODO doctest(Setfield)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
-using Setfield
+PerformanceTestTools.@include("perf.jl")
 include("test_examples.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")
@@ -11,7 +11,6 @@ include("test_setmacro.jl")
 include("test_setindex.jl")
 include("test_core.jl")
 include("test_functionlenses.jl")
-PerformanceTestTools.@include("perf.jl")
 doctest(Setfield)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,6 @@ include("test_setindex.jl")
 include("test_core.jl")
 include("test_functionlenses.jl")
 PerformanceTestTools.@include("perf.jl")
-# TODO doctest(Setfield)
+doctest(Setfield)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
-PerformanceTestTools.@include("perf.jl")
 include("test_examples.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")
@@ -11,6 +10,7 @@ include("test_setmacro.jl")
 include("test_setindex.jl")
 include("test_core.jl")
 include("test_functionlenses.jl")
+PerformanceTestTools.@include("perf.jl")
 doctest(Setfield)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 module TestSetfield
-
 import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
+using Setfield
 include("test_examples.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
-PerformanceTestTools.@include("perf.jl")
 include("test_examples.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")
@@ -12,8 +11,7 @@ include("test_setmacro.jl")
 include("test_setindex.jl")
 include("test_core.jl")
 include("test_functionlenses.jl")
-
-
+PerformanceTestTools.@include("perf.jl")
 # TODO doctest(Setfield)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,13 +4,13 @@ import PerformanceTestTools
 import Setfield
 using Documenter: doctest
 
-include("test_setindex.jl")
-include("test_examples.jl")
-include("test_setmacro.jl")
 include("test_core.jl")
 include("test_functionlenses.jl")
 include("test_staticarrays.jl")
 include("test_quicktypes.jl")
+include("test_setmacro.jl")
+include("test_setindex.jl")
+include("test_examples.jl")
 PerformanceTestTools.@include("perf.jl")
 
 doctest(Setfield)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -420,6 +420,17 @@ end
     @test @lens(_.a |> lbc) === @lens(_.a) ⨟ lbc
     @test @lens((_.a |> lbc).d) === ⨟(@lens(_.a), lbc , @lens(_.d))
     @test @lens(_.a |> lbc |> (@lens _[1]) |> lbc) === ⨟(@lens(_.a), lbc, @lens(_[1]), lbc)
+
+    @test (@lens _ |> _[1])            === (@lens _[1])
+    @test (@lens _ |> _.a)             === (@lens _.a)
+    @test (@lens _ |> _.a.b)           === (@lens _.a.b)
+    @test (@lens _ |> _.a[2])          === (@lens _.a[2])
+    @test (@lens _ |> first |> _[1])   === (@lens first(_)[1])
+    @test (@lens _ |> identity(first)) === first
+    twice = lens -> lens ∘ lens
+    @test (@lens _ |> twice(first)) === first ∘ first
+    @test (@lens _ |> first |> _.a |> (first ∘ last) |> _[2]) ===
+        (@lens (first ∘ last)(first(_).a)[2])
 end
 
 @testset "text/plain show" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -162,23 +162,23 @@ function test_getset_laws(lens, obj, val1, val2)
 
     # set ⨟ get
     val = lens(obj)
-    @test set(lens, obj, val) == obj
+    @test set(obj, lens, val) == obj
 
     # get ⨟ set
-    obj1 = set(lens, obj, val1)
+    obj1 = set(obj, lens, val1)
     @test lens(obj1) == val1
 
     # set idempotent
-    obj12 = set(lens, obj1, val2)
-    obj2 = set(lens, obj12, val2)
+    obj12 = set(obj1, lens, val2)
+    obj2 = set(obj12, lens, val2)
     @test obj12 == obj2
 end
 
 function test_modify_law(f, lens, obj)
-    obj_modify = modify(f, lens, obj)
+    obj_modify = modify(f, obj, lens)
     old_val = lens(obj)
     val = f(old_val)
-    obj_setfget = set(lens, obj, val)
+    obj_setfget = set(obj, lens, val)
     @test obj_modify == obj_setfget
 end
 
@@ -230,8 +230,8 @@ end
           ((@lens _             ),   :xy),
         ]
         @inferred lens(obj)
-        @inferred set(lens, obj, val)
-        @inferred modify(identity, lens, obj)
+        @inferred set(obj, lens, val)
+        @inferred modify(identity, obj, lens)
     end
 end
 
@@ -253,7 +253,7 @@ end
     l = @lens _[1]
     @test l isa Setfield.IndexLens
     @test l(obj) == 1
-    @test set(l, obj, 6) == (6,2,3)
+    @test set(obj, l, 6) == (6,2,3)
 
 
     l = @lens _[1:3]
@@ -266,34 +266,34 @@ end
     @test l isa Setfield.DynamicIndexLens
     obj = (1,2,3)
     @test l(obj) == 3
-    @test set(l, obj, true) == (1,2,true)
+    @test set(obj, l, true) == (1,2,true)
 
     l = @lens _[end÷2]
     @test l isa Setfield.DynamicIndexLens
     obj = (1,2,3)
     @test l(obj) == 1
-    @test set(l, obj, true) == (true,2,3)
+    @test set(obj, l, true) == (true,2,3)
 
     two = 2
     plusone(x) = x + 1
     l = @lens _.a[plusone(end) - two].b
     obj = (a=(1, (a=10, b=20), 3), b=4)
     @test l(obj) == 20
-    @test set(l, obj, true) == (a=(1, (a=10, b=true), 3), b=4)
+    @test set(obj, l, true) == (a=(1, (a=10, b=true), 3), b=4)
 end
 
 @testset "StaticNumbers" begin
     obj = (1, 2.0, '3')
     l = @lens _[static(1)]
     @test (@inferred l(obj)) === 1
-    @test (@inferred set(l, obj, 6.0)) === (6.0, 2.0, '3')
+    @test (@inferred set(obj, l, 6.0)) === (6.0, 2.0, '3')
     l = @lens _[static(1 + 1)]
     @test (@inferred l(obj)) === 2.0
-    @test (@inferred set(l, obj, 6)) === (1, 6, '3')
+    @test (@inferred set(obj, l, 6)) === (1, 6, '3')
     n = 1
     l = @lens _[static(3n)]
     @test (@inferred l(obj)) === '3'
-    @test (@inferred set(l, obj, 6)) === (1, 2.0, 6)
+    @test (@inferred set(obj, l, 6)) === (1, 2.0, 6)
 
     l = @lens _[static(1):static(3)]
     @test l([4,5,6,7]) == [4,5,6]
@@ -307,9 +307,9 @@ end
         sweeper_with_noconst = @set sweeper_with_const.axis = @lens _[2]
 
         function f(s)
-            a = sum(set(s.axis, s.model, 0))
+            a = sum(set(s.model, s.axis, 0))
             for i in 1:10
-                a += sum(set(s.axis, s.model, i))
+                a += sum(set(s.model, s.axis, i))
             end
             return a
         end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -122,6 +122,9 @@ end
     t = (1, 2, 3, 4)
     @test (@set t[length(t)] = 40) === (1, 2, 3, 40)
     @test (@set t[length(t) ÷ 2] = 20) === (1, 20, 3, 4)
+
+    t = (1, 2)
+    @test (@set t |> first = 10) === (10, 2)
 end
 
 
@@ -146,6 +149,9 @@ Base.show(io::IO, ::MIME"text/plain", ::LensWithTextPlain) =
             @lens last(first(_))
             @lens last(first(_.a))[1]
             UserDefinedLens()
+            @lens _ |> UserDefinedLens()
+            @lens UserDefinedLens()(_)
+            @lens _ |> ((x -> x)(first))
             (@lens _.a) ⨟ UserDefinedLens()
             UserDefinedLens() ⨟ (@lens _.b)
             (@lens _.a) ∘ UserDefinedLens()   ∘ (@lens _.b)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -397,23 +397,6 @@ end
     @test_throws ArgumentError Setfield.lensmacro(identity, :(_.[:a]))
 end
 
-@testset "@lens and ⨟" begin
-    @test @lens(⨟()) === @lens(_)
-    @test @lens(∘()) === @lens(_)
-    @test @lens(⨟(_.a)) === @lens(_.a)
-    @test @lens(∘(_.a)) === @lens(_.a)
-    @test @lens(⨟(_.a, _.b)) ===
-        @lens(_.a) ⨟ @lens(_.b) ===
-        @lens(_.b) ∘ @lens(_.a)
-    @test @lens(⨟(_.a, _.b, _.c)) === Setfield.lenscompose(@lens(_.a), @lens(_.b), @lens(_.c))
-
-    @test @lens(⨟(_[1])) === @lens(_[1])
-    @test @lens(⨟(_[1], _[2])) === @lens(_[1]) ⨟ @lens(_[2])
-    @test @lens(⨟(_[1], _[2], _[3])) === Setfield.lenscompose(@lens(_[1]), @lens(_[2]), @lens(_[3]))
-
-    @test @lens(_ ⨟ (_[1] ⨟ _.a) ⨟ first(_)) == @lens(_) ⨟ (@lens(_[1]) ⨟ @lens(_.a)) ⨟ @lens(first(_))
-end
-
 @testset "|>" begin
     lbc = @lens _.b.c
     @test @lens(_ |> lbc) === lbc
@@ -421,6 +404,7 @@ end
     @test @lens((_.a |> lbc).d) === ⨟(@lens(_.a), lbc , @lens(_.d))
     @test @lens(_.a |> lbc |> (@lens _[1]) |> lbc) === ⨟(@lens(_.a), lbc, @lens(_[1]), lbc)
 
+    @test @lens(_ |> _) === identity
     @test (@lens _ |> _[1])            === (@lens _[1])
     @test (@lens _ |> _.a)             === (@lens _.a)
     @test (@lens _ |> _.a.b)           === (@lens _.a.b)
@@ -431,6 +415,7 @@ end
     @test (@lens _ |> twice(first)) === first ∘ first
     @test (@lens _ |> first |> _.a |> (first ∘ last) |> _[2]) ===
         (@lens (first ∘ last)(first(_).a)[2])
+    @test (@lens _ |> _[1] |> _[2] |> _[3]) === @lens _[1][2][3]
 end
 
 @testset "text/plain show" begin

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -414,13 +414,12 @@ end
     @test @lens(_ ⨟ (_[1] ⨟ _.a) ⨟ first(_)) == @lens(_) ⨟ (@lens(_[1]) ⨟ @lens(_.a)) ⨟ @lens(first(_))
 end
 
-@testset "@lens ⨟ and \$" begin
+@testset "|>" begin
     lbc = @lens _.b.c
-    @test @lens($lbc) === lbc
-    @test @lens(_.a ⨟ $lbc) ===
-        @lens(_.a) ⨟ lbc
-    @test @lens(_.a ⨟ $lbc ⨟ _[1] ⨟ $lbc) ===
-        @lens(_.a) ⨟ lbc ⨟ @lens(_[1]) ⨟ lbc
+    @test @lens(_ |> lbc) === lbc
+    @test @lens(_.a |> lbc) === @lens(_.a) ⨟ lbc
+    @test @lens((_.a |> lbc).d) === ⨟(@lens(_.a), lbc , @lens(_.d))
+    @test @lens(_.a |> lbc |> (@lens _[1]) |> lbc) === ⨟(@lens(_.a), lbc, @lens(_[1]), lbc)
 end
 
 @testset "text/plain show" begin

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -2,6 +2,16 @@ module TestFunctionLenses
 using Test
 using Setfield
 
+@testset "os" begin
+    path = "hello.md"
+    path_new = @set splitext(path)[2] = ".jl"
+    @test path_new == "hello.jl"
+
+    path = joinpath("root", "somedir", "some.file")
+    path_new = @set splitdir(path)[1] = "otherdir"
+    @test path_new == joinpath("otherdir", "some.file")
+end
+
 @testset "first" begin
     obj = (1, 2.0, '3')
     l = @lens first(_)
@@ -67,4 +77,4 @@ end
     @test typeof(@set eltype(obj) = Pair{UInt, Float64}) === Dict{UInt, Float64}
 end
 
-end  # module
+end # module

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -5,8 +5,9 @@ using Setfield
 @testset "first" begin
     obj = (1, 2.0, '3')
     l = @lens first(_)
-    @test get(obj, l) === 1
-    @test set(obj, l, "1") === ("1", 2.0, '3')
+    @test l === first
+    @test l(obj) === 1
+    @test set(l, obj, "1") === ("1", 2.0, '3')
     @test (@set first(obj) = "1") === ("1", 2.0, '3')
 
     obj2 = (a=((b=1,), 2), c=3)
@@ -16,8 +17,8 @@ end
 @testset "last" begin
     obj = (1, 2.0, '3')
     l = @lens last(_)
-    @test get(obj, l) === '3'
-    @test set(obj, l, '4') === (1, 2.0, '4')
+    @test l === last
+    @test set(l, obj, '4') === (1, 2.0, '4')
     @test (@set last(obj) = '4') === (1, 2.0, '4')
 
     obj2 = (a=(1, (b=2,)), c=3)
@@ -28,21 +29,21 @@ end
     @test @set(eltype(Int) = Float32) === Float32
     @test @set(eltype(1.0) = UInt8)   === UInt8(1)
 
-    @inferred set(Int, @lens(eltype(_)), Float32)
-    @inferred set(1.2, @lens(eltype(_)), Float32)
+    @inferred set(eltype, Int, Float32)
+    @inferred set(eltype, 1.2, Float32)
 
 end
 
 @testset "eltype(::Type{<:Array})" begin
     obj = Vector{Int}
-    @inferred set(obj, @lens(eltype(_)), Float32)
+    @inferred set(eltype, obj, Float32)
     obj2 = @set eltype(obj) = Float64
     @test obj2 === Vector{Float64}
 end
 
 @testset "eltype(::Array)" begin
     obj = [1, 2, 3]
-    @inferred set(obj, @lens(eltype(_)), Float32)
+    @inferred set(eltype, obj, Float32)
     obj2 = @set eltype(obj) = Float64
     @test eltype(obj2) == Float64
     @test obj == obj2

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -7,7 +7,7 @@ using Setfield
     l = @lens first(_)
     @test l === first
     @test l(obj) === 1
-    @test set(l, obj, "1") === ("1", 2.0, '3')
+    @test set(obj, l, "1") === ("1", 2.0, '3')
     @test (@set first(obj) = "1") === ("1", 2.0, '3')
 
     obj2 = (a=((b=1,), 2), c=3)
@@ -18,7 +18,7 @@ end
     obj = (1, 2.0, '3')
     l = @lens last(_)
     @test l === last
-    @test set(l, obj, '4') === (1, 2.0, '4')
+    @test set(obj, l, '4') === (1, 2.0, '4')
     @test (@set last(obj) = '4') === (1, 2.0, '4')
 
     obj2 = (a=(1, (b=2,)), c=3)
@@ -29,21 +29,21 @@ end
     @test @set(eltype(Int) = Float32) === Float32
     @test @set(eltype(1.0) = UInt8)   === UInt8(1)
 
-    @inferred set(eltype, Int, Float32)
-    @inferred set(eltype, 1.2, Float32)
+    @inferred set(Int, eltype, Float32)
+    @inferred set(1.2, eltype, Float32)
 
 end
 
 @testset "eltype(::Type{<:Array})" begin
     obj = Vector{Int}
-    @inferred set(eltype, obj, Float32)
+    @inferred set(obj, eltype, Float32)
     obj2 = @set eltype(obj) = Float64
     @test obj2 === Vector{Float64}
 end
 
 @testset "eltype(::Array)" begin
     obj = [1, 2, 3]
-    @inferred set(eltype, obj, Float32)
+    @inferred set(obj, eltype, Float32)
     obj2 = @set eltype(obj) = Float64
     @test eltype(obj2) == Float64
     @test obj == obj2

--- a/test/test_setmacro.jl
+++ b/test/test_setmacro.jl
@@ -23,13 +23,13 @@ using StaticNumbers
 @testset "setmacro, lensmacro isolation" begin
 
     # test that no symbols like `IndexLens` are needed:
-    @test Clone.@lens(_                                   ) isa Setfield.Lens
-    @test Clone.@lens(_.a                                 ) isa Setfield.Lens
-    @test Clone.@lens(_[1]                                ) isa Setfield.Lens
-    @test Clone.@lens(first(_)                            ) isa Setfield.Lens
-    @test Clone.@lens(_[end]                              ) isa Setfield.Lens
-    @test Clone.@lens(_[static(1)]                           ) isa Setfield.Lens
-    @test Clone.@lens(_.a[1][end, end-2].b[static(1), static(1)]) isa Setfield.Lens
+    Clone.@lens(_                                         )
+    Clone.@lens(_.a                                       )
+    Clone.@lens(_[1]                                      )
+    Clone.@lens(first(_)                                  )
+    Clone.@lens(_[end]                                    )
+    Clone.@lens(_[static(1)]                              )
+    Clone.@lens(_.a[1][end, end-2].b[static(1), static(1)])
 
     @test Setfield.@lens(_.a) === Clone.@lens(_.a)
     @test Setfield.@lens(_.a.b) === Clone.@lens(_.a.b)

--- a/test/test_setmacro.jl
+++ b/test/test_setmacro.jl
@@ -1,16 +1,13 @@
 module TestSetMacro
 
 module Clone
-using Setfield: setmacro, lensmacro
-
-macro lens(ex)
-    lensmacro(identity, ex)
-end
-
-macro set(ex)
-    setmacro(identity, ex)
-end
-
+    import Setfield: setmacro, lensmacro
+    macro lens(ex)
+        lensmacro(identity, ex)
+    end
+    macro set(ex)
+        setmacro(identity, ex)
+    end
 end#module Clone
 
 using Setfield: Setfield
@@ -47,4 +44,3 @@ using StaticNumbers
 end
 
 end#module
-

--- a/test/test_staticarrays.jl
+++ b/test/test_staticarrays.jl
@@ -9,9 +9,9 @@ using StaticNumbers
     @testset for l in [
             (@lens _[2,1]),
         ]
-        @test get(obj, l) == 3
-        @test set(obj, l, 5) == StaticArrays.@SMatrix [1 2; 5 4]
-        @test setindex(obj, 5, 2, 1) == StaticArrays.@SMatrix [1 2; 5 4]
+        @test l(obj) === 3
+        @test set(l, obj, 5)         === StaticArrays.@SMatrix [1 2; 5 4]
+        @test setindex(obj, 5, 2, 1) === StaticArrays.@SMatrix [1 2; 5 4]
     end
 
     v = @SVector [1,2,3]
@@ -34,8 +34,8 @@ using StaticNumbers
             (a=5, b=50) (a=6, b=60)
         ]
         obj = (a=m_orig, b=4)
-        @test get(obj, l1) === get(obj, l2) === 30
-        @test set(obj, l1, 3000) === set(obj, l2, 3000) === (a=m_mod, b=4)
+        @test l1(obj) === l2(obj) === 30
+        @test set(l1, obj, 3000) === set(l2, obj, 3000) === (a=m_mod, b=4)
     end
 end
 end

--- a/test/test_staticarrays.jl
+++ b/test/test_staticarrays.jl
@@ -10,7 +10,7 @@ using StaticNumbers
             (@lens _[2,1]),
         ]
         @test l(obj) === 3
-        @test set(l, obj, 5)         === StaticArrays.@SMatrix [1 2; 5 4]
+        @test set(obj, l, 5)         === StaticArrays.@SMatrix [1 2; 5 4]
         @test setindex(obj, 5, 2, 1) === StaticArrays.@SMatrix [1 2; 5 4]
     end
 
@@ -35,7 +35,7 @@ using StaticNumbers
         ]
         obj = (a=m_orig, b=4)
         @test l1(obj) === l2(obj) === 30
-        @test set(l1, obj, 3000) === set(l2, obj, 3000) === (a=m_mod, b=4)
+        @test set(obj, l1, 3000) === set(obj, l2, 3000) === (a=m_mod, b=4)
     end
 end
 end


### PR DESCRIPTION
See #146 List of changes:
* Get rid of `Lens` type, lenses are fully duck typed now
* Replace `get(obj, lens)` by `lens(obj)`
* Replace `set(obj, lens, val)` by `set(lens, obj, val)`
* Replace `modify(f, obj, lens)` by `modify(f, lens, obj)`
* Replace `lens1 ∘  lens2` by `lens2 ∘  lens1`
* Replace `@set!` by `@reset`

@tkf what you think about it. Especially replacing `set(obj, lens, val)` by `set(lens, obj, val)`. In the function lens picture, this feels more natural. Also, it makes a possible future multi object `modify(f, lens, obj, objs...)` easier.

Tests pass locally, except for doctests. Docs are telling lies I plan to fix these when we know what API changes we actually want.
I agree this change is a good opportunity to change the package name.
