### PR TITLE
Fix #161: Implement == and hash for IndexLens and ComposedLens

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -9,6 +9,17 @@ export constructorof
 import Base: get, hash, ==
 using Base: getproperty
 
+
+# used for hashing
+function make_salt(s64::UInt64)::UInt
+    if UInt === UInt64
+        return s64
+    else
+        return UInt32(s64 >> 32) ^ UInt32(s64 & 0x00000000ffffffff)
+    end
+end
+
+
 """
     Lens
 
@@ -119,7 +130,9 @@ end
 function ==(l1::ComposedLens{LO, LI}, l2::ComposedLens{LO, LI}) where {LO, LI}
     return l1.outer == l2.outer && l1.inner == l2.inner
 end
-hash(l::ComposedLens, h::UInt) = hash(l.outer, hash(l.inner, h))
+
+const SALT_COMPOSEDLENS = make_salt(0xcf7322dcc2129a31)
+hash(l::ComposedLens, h::UInt) = hash(l.outer, hash(l.inner, SALT_INDEXLENS + h))
 
 """
     compose([lens₁, [lens₂, [lens₃, ...]]])
@@ -179,8 +192,11 @@ end
 struct IndexLens{I <: Tuple} <: Lens
     indices::I
 end
+
 ==(l1::IndexLens{I}, l2::IndexLens{I}) where {I} = l1.indices == l2.indices
-hash(l::IndexLens, h::UInt) = hash(l.indices, h)
+
+const SALT_INDEXLENS = make_salt(0x8b4fd6f97c6aeed6)
+hash(l::IndexLens, h::UInt) = hash(l.indices, SALT_INDEXLENS + h)
 
 Base.@propagate_inbounds function get(obj, l::IndexLens)
     getindex(obj, l.indices...)

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -119,7 +119,7 @@ end
 function ==(l1::ComposedLens{LO, LI}, l2::ComposedLens{LO, LI}) where {LO, LI}
     return l1.outer == l2.outer && l1.inner == l2.inner
 end
-hash(l::ComposedLens, h::UInt) = hash(l.outer, hash(l.inner, hash(:ComposedLens, h)))
+hash(l::ComposedLens, h::UInt) = hash(l.outer, hash(l.inner, h))
 
 """
     compose([lens₁, [lens₂, [lens₃, ...]]])
@@ -180,7 +180,7 @@ struct IndexLens{I <: Tuple} <: Lens
     indices::I
 end
 ==(l1::IndexLens{I}, l2::IndexLens{I}) where {I} = l1.indices == l2.indices
-hash(l::IndexLens, h::UInt) = hash(l.indices, hash(:IndexLens, h))
+hash(l::IndexLens, h::UInt) = hash(l.indices, h)
 
 Base.@propagate_inbounds function get(obj, l::IndexLens)
     getindex(obj, l.indices...)

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -6,7 +6,7 @@ export setproperties
 export constructorof
 
 
-import Base: get
+import Base: get, hash, ==
 using Base: getproperty
 
 """
@@ -99,6 +99,7 @@ struct IdentityLens <: Lens end
 get(obj, ::IdentityLens) = obj
 set(obj, ::IdentityLens, val) = val
 
+
 struct PropertyLens{fieldname} <: Lens end
 
 function get(obj, l::PropertyLens{field}) where {field}
@@ -114,6 +115,11 @@ struct ComposedLens{LO, LI} <: Lens
     outer::LO
     inner::LI
 end
+
+function ==(l1::ComposedLens{LO, LI}, l2::ComposedLens{LO, LI}) where {LO, LI}
+    return l1.outer == l2.outer && l1.inner == l2.inner
+end
+hash(l::ComposedLens, h::UInt) = hash(l.outer, hash(l.inner, hash(:ComposedLens, h)))
 
 """
     compose([lens₁, [lens₂, [lens₃, ...]]])
@@ -173,6 +179,8 @@ end
 struct IndexLens{I <: Tuple} <: Lens
     indices::I
 end
+==(l1::IndexLens{I}, l2::IndexLens{I}) where {I} = l1.indices == l2.indices
+hash(l::IndexLens, h::UInt) = hash(l.indices, hash(:IndexLens, h))
 
 Base.@propagate_inbounds function get(obj, l::IndexLens)
     getindex(obj, l.indices...)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -205,6 +205,26 @@ end
     end
 end
 
+@testset "equality & hashing" begin
+    # singletons (identity and property lens) are object equal
+    for (l, r) ∈ [
+        @lens(_) => @lens(_),
+        @lens(_.a) => @lens(_.a)
+    ]
+        @test l === r
+    end
+
+    # composite and index lenses are structurally equal
+    for (l, r) ∈ [
+        @lens(_[1]) => @lens(_[1])
+        @lens(_.a[2]) => @lens(_.a[2])
+    ]
+        @test l == r
+        @test hash(l) == hash(r)
+    end
+end
+
+
 @testset "type stability" begin
     o1 = 2
     o22 = 2


### PR DESCRIPTION
Now I'm not an expert in these matters, but is seems the bottleneck is not hashing the tuples, but the types or symbols (since [`hash(::Symbol)` falls back to `objectid`](https://github.com/JuliaLang/julia/blob/73a963d37882d70cadb1faf168777514d2b450d1/base/hashing.jl#L27), too).  In the commit without adding type symbols to `hash` (https://github.com/jw3126/Setfield.jl/commit/2ca540462d30de73d3474d80c84fa72aec6115d1):

```julia
julia> @benchmark hash($((1, )))
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  0.024 ns … 0.074 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     0.028 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   0.029 ns ± 0.003 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                          
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ ▁
  0.074 ns       Histogram: frequency by time      0.026 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark hash($(@lens(_[1])))
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  0.024 ns … 12.903 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     0.028 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   0.030 ns ±  0.129 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                           
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ ▁
  0.063 ns       Histogram: frequency by time       0.027 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

With the symbols (https://github.com/jw3126/Setfield.jl/commit/880daf445f735b2c94fc1b037688f3daf92dfe30):

```julia
julia> @benchmark hash($((1, )))
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  0.024 ns … 0.062 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     0.028 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   0.029 ns ± 0.003 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                          
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁ ▁
  0.062 ns       Histogram: frequency by time      0.027 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark hash($(@lens(_[1])))
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):   9.690 ns … 44.821 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.423 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.712 ns ±  1.721 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                            
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁▁▁  ▁
  15.1 ns         Histogram: frequency by time        10.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Without the symbol, an index lens hashes to the same as the underlying tuple, though:

```julia
julia> hash(@lens(_[1]))
0xf45b969ce741991e

julia> hash((1,))
0xf45b969ce741991e
```

That _could_ be solved by using a magic constant instead, but is that a good idea?

CC @torfjelde 