### PR TITLE
Remove type parameters from == methods of IndexLens and CompositeLens

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/lens.jl
+++ b/src/lens.jl
@@ -127,7 +127,7 @@ struct ComposedLens{LO, LI} <: Lens
     inner::LI
 end
 
-function ==(l1::ComposedLens{LO, LI}, l2::ComposedLens{LO, LI}) where {LO, LI}
+function ==(l1::ComposedLens, l2::ComposedLens)
     return l1.outer == l2.outer && l1.inner == l2.inner
 end
 
@@ -193,7 +193,7 @@ struct IndexLens{I <: Tuple} <: Lens
     indices::I
 end
 
-==(l1::IndexLens{I}, l2::IndexLens{I}) where {I} = l1.indices == l2.indices
+==(l1::IndexLens, l2::IndexLens) = l1.indices == l2.indices
 
 const SALT_INDEXLENS = make_salt(0x8b4fd6f97c6aeed6)
 hash(l::IndexLens, h::UInt) = hash(l.indices, SALT_INDEXLENS + h)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -209,7 +209,7 @@ end
     # singletons (identity and property lens) are egal
     for (l1, l2) ∈ [
         @lens(_) => @lens(_),
-        @lens(_.a) => @lens(_.a)
+        @lens(_.a) => @lens(_.a),
     ]
         @test l1 === l2
         @test l1 == l2
@@ -218,9 +218,12 @@ end
 
     # composite and index lenses are structurally equal
     for (l1, l2) ∈ [
-        @lens(_[1]) => @lens(_[1])
-        @lens(_.a[2]) => @lens(_.a[2])
-        @lens(_.a.b[3]) => @lens(_.a.b[3])
+        @lens(_[1]) => @lens(_[1]),
+        @lens(_.a[2]) => @lens(_.a[2]),
+        @lens(_.a.b[3]) => @lens(_.a.b[3]),
+        @lens(_[1:10]) => @lens(_[1:10]),
+        @lens(_.a[2:20]) => @lens(_.a[2:20]),
+        @lens(_.a.b[3:30]) => @lens(_.a.b[3:30]),
     ]
         @test l1 == l2
         @test hash(l1) == hash(l2)
@@ -228,11 +231,26 @@ end
 
     # inequality
     for (l1, l2) ∈ [
-        @lens(_[1]) => @lens(_[2])
-        @lens(_.a[1]) => @lens(_.a[2])
-        @lens(_.a[1]) => @lens(_.b[1])
+        @lens(_[1]) => @lens(_[2]),
+        @lens(_.a[1]) => @lens(_.a[2]),
+        @lens(_.a[1]) => @lens(_.b[1]),
+        @lens(_[1:10]) => @lens(_[2:20]),
+        @lens(_.a[1:10]) => @lens(_.a[2:20]),
+        @lens(_.a[1:10]) => @lens(_.b[1:10]),
     ]
         @test l1 != l2
+    end
+
+    # equality with non-equal range types (#165)
+    for (l1, l2) ∈ [
+        @lens(_[1:10]) => @lens(_[Base.OneTo(10)]),
+        @lens(_.a[1:10]) => @lens(_.a[Base.OneTo(10)]),
+        @lens(_.a.b[1:10]) => @lens(_.a.b[Base.OneTo(10)]),
+        @lens(_.a[Base.StepRange(1, 1, 5)].b[1:10]) => @lens(_.a[1:5].b[Base.OneTo(10)]),
+        @lens(_.a.b[1:3]) => @lens(_.a.b[[1, 2, 3]]),
+    ]
+        @test l1 == l2
+        @test hash(l1) == hash(l2)
     end
 
     # Hash property: equality implies equal hashes, or in other terms:


### PR DESCRIPTION
Fixes #165.

I'm not quite sure whether this is considered breaking; it changes behaviour of equality for some of the methods...?