### PR TITLE
Allow interpolation of properties

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -123,12 +123,17 @@ function parse_obj_lenses(ex)
             lens = :($IndexLens($index))
         end
     elseif @capture(ex, front_.property_)
-        property isa Union{Symbol,String} || throw(ArgumentError(
-            string("Error while parsing :($ex). Second argument to `getproperty` can only be",
-                   "a `Symbol` or `String` literal, received `$property` instead.")
-        ))
         obj, frontlens = parse_obj_lenses(front)
-        lens = :($PropertyLens{$(QuoteNode(property))}())
+        if property isa Union{Symbol,String}
+            lens = :($PropertyLens{$(QuoteNode(property))}())
+        elseif is_interpolation(property)
+            lens = :($PropertyLens{$(esc(property.args[1]))}())
+        else
+            throw(ArgumentError(
+                string("Error while parsing :($ex). Second argument to `getproperty` can only be",
+                       "a `Symbol` or `String` literal, received `$property` instead.")
+            ))
+        end
     elseif @capture(ex, f_(front_))
         obj, frontlens = parse_obj_lenses(front)
         lens = :($FunctionLens($(esc(f))))

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -236,6 +236,11 @@ julia> t = ("one", "two")
 
 julia> set(t, (@lens _[1]), "1")
 ("1", "two")
+
+julia> # Indices are always evaluated in external scope; for properties, you can use interpolation:
+       n, i = :a, 10
+       @lens(_.\$n[i, i+1])
+(@lens _.a[10, 11])
 ```
 
 """

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -515,7 +515,7 @@ end
     fancy(name, suffix) = Symbol("fancy_", name, suffix)
     @test @lens(_.$name) == @lens(_.a)
     @test @lens(_.x[1, :].$name) == @lens(_.x[1, :].a)
-    @test @lens(_.x[1, :].$(fancy(name, "✨"))) == @lens(_.x[1, :].var"fancy_a✨")
+    @test @lens(_.x[1, :].$(fancy(name, "✨"))) == @lens(_.x[1, :].fancy_a✨)
 end
 
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -509,6 +509,9 @@ end
     @test @lens($lbc)== lbc
     @test @lens(_.a ∘ $lbc) == @lens(_.a) ∘ lbc
     @test @lens(_.a ∘ $lbc ∘ _[1] ∘ $lbc) == @lens(_.a) ∘ lbc ∘ @lens(_[1]) ∘ lbc
+
+    name = :a
+    @test @lens(_.$name) == @lens(_.a)
 end
 
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -510,8 +510,12 @@ end
     @test @lens(_.a ∘ $lbc) == @lens(_.a) ∘ lbc
     @test @lens(_.a ∘ $lbc ∘ _[1] ∘ $lbc) == @lens(_.a) ∘ lbc ∘ @lens(_[1]) ∘ lbc
 
+    # property interpolation
     name = :a
+    fancy(name, suffix) = Symbol("fancy_", name, suffix)
     @test @lens(_.$name) == @lens(_.a)
+    @test @lens(_.x[1, :].$name) == @lens(_.x[1, :].a)
+    @test @lens(_.x[1, :].$(fancy(name, "✨"))) == @lens(_.x[1, :].var"fancy_a✨")
 end
 
 end


### PR DESCRIPTION
This comes up in some VarName use cases in DynamicPPL (cf. https://github.com/TuringLang/AbstractPPL.jl/issues/46).

I simply add a case to check property access with `is_interpolation`.

Any ideas/requirements for more test cases?
