### PR TITLE
Depend on StaticArraysCore.jl; remove Requires.jl dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 [compat]
 ConstructionBase = "0.1, 1.0"
 MacroTools = "0.4.4, 0.5"
-julia = "1"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.0.1"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 ConstructionBase = "0.1, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,15 @@
 name = "Setfield"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ConstructionBase = "0.1, 1.0"
 MacroTools = "0.4.4, 0.5"
-Requires = "0.5, 1.0"
 julia = "1"
 
 [extras]

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -26,5 +26,4 @@ for n in names(Setfield, all=true)
         @eval Base.show(io::IO, l::$T) = _show(io, nothing, l)
     end
 end
-
 end

--- a/src/Setfield.jl
+++ b/src/Setfield.jl
@@ -2,7 +2,7 @@ __precompile__(true)
 module Setfield
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
-using Requires: @require
+using StaticArraysCore
 
 if VERSION < v"1.1-"
     using Future: copy!
@@ -24,13 +24,6 @@ for n in names(Setfield, all=true)
     T = getproperty(Setfield, n)
     if T isa Type && T <: Lens && (T === ComposedLens || has_atlens_support(T))
         @eval Base.show(io::IO, l::$T) = _show(io, nothing, l)
-    end
-end
-
-function __init__()
-    @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin
-        setindex(a::StaticArrays.StaticArray, args...) =
-            Base.setindex(a, args...)
     end
 end
 

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -21,5 +21,5 @@ Base.@propagate_inbounds function setindex(d0::AbstractDict, v, k)
     return d
 end
 
-setindex(a::StaticArrays.StaticArray, args...) =
+setindex(a::StaticArraysCore.StaticArray, args...) =
     Base.setindex(a, args...)

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -20,3 +20,6 @@ Base.@propagate_inbounds function setindex(d0::AbstractDict, v, k)
     d[k] = v
     return d
 end
+
+setindex(a::StaticArrays.StaticArray, args...) =
+    Base.setindex(a, args...)


### PR DESCRIPTION
StaticArrays has recently been refactored with the interface contained in StaticArraysCore; a much lighter dependency. This allows to remove the dynamic loading of the StaticArrays package, which has the potential to prevent method invalidations during precompilation of downstream packages.

All tests pass locally (Julia 1.7.2).

Also addresses https://github.com/jw3126/Setfield.jl/issues/164