### PR TITLE
Adding `hasproperty` overload for lenses

### DIFF
--- a/src/lens.jl
+++ b/src/lens.jl
@@ -259,3 +259,7 @@ struct FunctionLens{f} <: Lens end
 FunctionLens(f) = FunctionLens{f}()
 
 get(obj, ::FunctionLens{f}) where f = f(obj)
+
+
+Base.hasproperty(obj, l::Setfield.ComposedLens) = hasproperty(obj, l.outer)
+Base.hasproperty(obj, l::PropertyLens{f}) where f = hasproperty(obj, f)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -518,4 +518,14 @@ end
     @test @lens(_.x[1, :].$(fancy(name, "✨"))) == @lens(_.x[1, :].fancy_a✨)
 end
 
+@testset "hasproperty" begin
+    obj = (x=1,)
+
+    l1 = @lens _.x
+    l2 = @lens _.y
+
+    @test hasproperty(obj, l1)
+    @test !hasproperty(obj, l2)
+end
+
 end


### PR DESCRIPTION
It's useful to have the `hasproperty(obj, lens)` function in some cases before calling `Setfield.set(obj, lens, val)`