### PR TITLE
Allow for proposed new parsing of `array[end]` in Setfield

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -65,20 +65,21 @@ const HAS_BEGIN_INDEXING = VERSION ≥ v"1.5.0-DEV.666"
 
 function need_dynamic_lens(ex)
     return foldtree(false, ex) do yes, x
-        (yes || x === :end || (HAS_BEGIN_INDEXING && x === :begin) || x === :_)
+        (yes || x === :end || (HAS_BEGIN_INDEXING && x === :begin) ||
+            x == Expr(:end) || (HAS_BEGIN_INDEXING && x == Expr(:begin)) || x === :_)
     end
 end
 
 function lower_index(collection::Symbol, index, dim)
     if isexpr(index, :call)
         return Expr(:call, lower_index.(collection, index.args, dim)...)
-    elseif (index === :end)
+    elseif (index === :end || index == Expr(:end))
         if dim === nothing
             return :($(Base.lastindex)($collection))
         else
             return :($(Base.lastindex)($collection, $dim))
         end
-    elseif HAS_BEGIN_INDEXING && (index === :begin)
+    elseif HAS_BEGIN_INDEXING && (index === :begin || index == Expr(:begin))
         if dim === nothing
             return :($(Base.firstindex)($collection))
         else


### PR DESCRIPTION
This is essentially the same change as https://github.com/JuliaObjects/Accessors.jl/pull/196. Description copied below:

> To fix [JuliaLang/julia#57269](https://github.com/JuliaLang/julia/issues/57269), a small-but-breaking AST change is needed (PR [JuliaLang/julia#57368](https://github.com/JuliaLang/julia/pull/57368)). The `set` macro in Setfield and Accessors breaks, and enough packages depend on this macro that it needs to be updated before deciding whether to merge the julialang PR.
> 
> This PR only recognizes the new way of parsing `array[end]`, and should not change any behaviour when used with the current parser.

